### PR TITLE
Layer: refactor allocate_bytes/words

### DIFF
--- a/libcrafter/crafter/Layer.cpp
+++ b/libcrafter/crafter/Layer.cpp
@@ -221,22 +221,7 @@ void Crafter::Layer::Print(std::ostream& str) const {
 
 /* Allocate a number of octets into the layer */
 void Crafter::Layer::allocate_words(size_t nwords) {
-	/* Delete memory allocated */
-	if (size)
-		delete [] raw_data;
-
-	/* Set the size */
-	size = nwords * sizeof(word);
-	/* Size in bytes of the header */
-	bytes_size = nwords * sizeof(word);
-
-	/* Allocate the raw data buffer */
-	raw_data = new byte[size];
-
-	/* And set the buffer to zero */
-	for (unsigned int i = 0 ; i < size ; i++)
-		raw_data[i] = 0x00;
-
+	allocate_bytes(nwords * sizeof(word));
 }
 
 /* Allocate a number of bytes into the layer */

--- a/libcrafter/crafter/Layer.cpp
+++ b/libcrafter/crafter/Layer.cpp
@@ -254,9 +254,7 @@ void Crafter::Layer::allocate_bytes(size_t nbytes) {
 	raw_data = new byte[nbytes];
 
 	/* And set the buffer to zero */
-	for (unsigned int i = 0 ; i < size ; i++)
-		raw_data[i] = 0x00;
-
+	memset(raw_data, 0, size);
 }
 
 size_t Crafter::Layer::GetData(byte* data) const {


### PR DESCRIPTION
- memset() is usually a compiler intrisic and as such is usually optimized (e.g. using SIMD) yielding better performance than per-byte initialization
- Since allocate_words was exactly the same code than allocate_bytes (but just adding a multiplicative factor to account for the size difference), I merged both functions.