### PR TITLE
Added support for IPv6 Routing extension header as well as the Segment Routing one

### DIFF
--- a/libcrafter/Makefile.am
+++ b/libcrafter/Makefile.am
@@ -100,6 +100,10 @@ libcrafter_la_SOURCES = crafter/Layer.cpp \
 						crafter/Protocols/IPv6Craft.cpp \
 						crafter/Protocols/IPv6FragmentationHeaderCraft.cpp \
 						crafter/Protocols/IPv6FragmentationHeaderConstructor.cpp \
+						crafter/Protocols/IPv6RoutingHeaderLayerCraft.cpp \
+						crafter/Protocols/IPv6RoutingHeaderLayerConstructor.cpp \
+						crafter/Protocols/IPv6SegmentRoutingHeaderCraft.cpp \
+						crafter/Protocols/IPv6SegmentRoutingHeaderConstructor.cpp \
 						crafter/Protocols/IPLayer.cpp \
 						crafter/Protocols/NullLoopbackConstructor.cpp \
 						crafter/Protocols/NullLoopbackCraft.cpp \
@@ -178,6 +182,8 @@ nobase_crafter_include_HEADERS =crafter.h \
 								crafter/Protocols/SLL.h \
 								crafter/Protocols/IPv6.h \
 								crafter/Protocols/IPv6FragmentationHeader.h \
+								crafter/Protocols/IPv6RoutingHeaderLayer.h \
+								crafter/Protocols/IPv6SegmentRoutingHeader.h \
 								crafter/Protocols/IPLayer.h \
 								crafter/Protocols/NullLoopback.h \
 						        crafter/Protocols/ICMPv6Layer.h \

--- a/libcrafter/crafter/Crafter.h
+++ b/libcrafter/crafter/Crafter.h
@@ -72,6 +72,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /* IPv6 Protocol Implementation */
 #include "Protocols/IPv6.h"
 #include "Protocols/IPv6FragmentationHeader.h"
+#include "Protocols/IPv6RoutingHeaderLayer.h"
 
 /* IMCP base class */
 #include "Protocols/ICMPLayer.h"

--- a/libcrafter/crafter/Crafter.h
+++ b/libcrafter/crafter/Crafter.h
@@ -73,6 +73,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Protocols/IPv6.h"
 #include "Protocols/IPv6FragmentationHeader.h"
 #include "Protocols/IPv6RoutingHeaderLayer.h"
+#include "Protocols/IPv6SegmentRoutingHeader.h"
 
 /* IMCP base class */
 #include "Protocols/ICMPLayer.h"

--- a/libcrafter/crafter/InitCrafter.cpp
+++ b/libcrafter/crafter/InitCrafter.cpp
@@ -77,6 +77,10 @@ void Crafter::InitCrafter() {
     IPv6RoutingHeaderLayer ipv6_rtg_dummy;
 	/* Register the protocol, this is executed only once */
 	Protocol::AccessFactory()->Register(&ipv6_rtg_dummy);
+    
+    IPv6SegmentRoutingHeader ipv6_sr_dummy;
+	/* Register the protocol, this is executed only once */
+	Protocol::AccessFactory()->Register(&ipv6_sr_dummy);
 
 	UDP udp_dummy;
 	/* Register the protocol, this is executed only once */

--- a/libcrafter/crafter/InitCrafter.cpp
+++ b/libcrafter/crafter/InitCrafter.cpp
@@ -73,6 +73,10 @@ void Crafter::InitCrafter() {
 	IPv6FragmentationHeader ipv6_frag_dummy;
 	/* Register the protocol, this is executed only once */
 	Protocol::AccessFactory()->Register(&ipv6_frag_dummy);
+    
+    IPv6RoutingHeaderLayer ipv6_rtg_dummy;
+	/* Register the protocol, this is executed only once */
+	Protocol::AccessFactory()->Register(&ipv6_rtg_dummy);
 
 	UDP udp_dummy;
 	/* Register the protocol, this is executed only once */

--- a/libcrafter/crafter/ProtoSource/IPv6RoutingHeaderLayer.src
+++ b/libcrafter/crafter/ProtoSource/IPv6RoutingHeaderLayer.src
@@ -1,0 +1,6 @@
+name IPv6RoutingHeaderLayer
+protoid 0x2b00
+ByteField NextHeader    0 0 0
+ByteField HeaderExtLen  0 1 0
+ByteField RoutingType   0 2 0
+ByteField SegmentLeft   0 3 0

--- a/libcrafter/crafter/ProtoSource/IPv6SegmentRoutingHeader.src
+++ b/libcrafter/crafter/ProtoSource/IPv6SegmentRoutingHeader.src
@@ -1,0 +1,11 @@
+name IPv6SegmentRoutingHeader
+protoid 0x2b04
+ByteField FirstSegment  1 0                      0
+BitFlag   CFlag         1 8  "Cleanup"   "Keep"  0
+BitFlag   PFlag         1 9  "Protected" "NoFRR" 0
+BitsField Reserved      1 10 2                   0
+BitsField PolicyFlag1   1 12 3                   0
+BitsField PolicyFlag2   1 15 3                   0
+BitsField PolicyFlag3   1 18 3                   0
+BitsField PolicyFlag4   1 21 3                   0
+ByteField HMACKeyID     1 3                      0

--- a/libcrafter/crafter/Protocols/IPv6Craft.cpp
+++ b/libcrafter/crafter/Protocols/IPv6Craft.cpp
@@ -27,6 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "IPv6.h"
 #include "ICMPv6Layer.h"
+#include "IPv6RoutingHeaderLayer.h"
 
 using namespace Crafter;
 using namespace std;
@@ -39,6 +40,8 @@ short_word IPv6::GetIPv6NextHeader(short_word transport_layer) {
         short_word top_id = transport_layer >> 8;
         if (top_id == (ICMPv6Layer::PROTO >> 8))
             return ICMPv6Layer::PROTO >> 8;
+        else if (top_id == (IPv6RoutingHeaderLayer::PROTO >> 8))
+            return IPv6RoutingHeaderLayer::PROTO >> 8;
         else
             return transport_layer;
     } else
@@ -78,6 +81,10 @@ Layer* IPv6::GetNextLayer(ParseInfo *info, short_word network_layer) {
 		/* Get ICMPv6 type */
 		short_word icmpv6_layer = (info->raw_data + info->offset)[0];
 		return ICMPv6Layer::Build(icmpv6_layer);
+	} else if (network_layer == (IPv6RoutingHeaderLayer::PROTO >> 8)) {
+        /* Get Routing Header Type */
+        byte routing_type = (info->raw_data + info->offset)[2];
+        return IPv6RoutingHeaderLayer::Build(routing_type);
     } else
         return Protocol::AccessFactory()->GetLayerByID(network_layer);
 }

--- a/libcrafter/crafter/Protocols/IPv6RoutingHeaderLayer.h
+++ b/libcrafter/crafter/Protocols/IPv6RoutingHeaderLayer.h
@@ -1,0 +1,128 @@
+/*
+Copyright (c) 2015, Olivier Tilmans
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL OLIVIER TILMANS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef IPV6ROUTINGHEADERLAYER_H_
+#define IPV6ROUTINGHEADERLAYER_H_
+
+#include "../Layer.h"
+
+namespace Crafter {
+
+    class IPv6RoutingHeaderLayer: public Layer {
+
+        Constructor GetConstructor() const {
+            return IPv6RoutingHeaderLayer::IPv6RoutingHeaderLayerConstFunc;
+        };
+
+        static Layer* IPv6RoutingHeaderLayerConstFunc() {
+            return new IPv6RoutingHeaderLayer;
+        };
+
+        void DefineProtocol();
+
+        void SetDefaultValues();
+
+    protected:
+        virtual void Craft();
+
+        virtual void ParseLayerData(ParseInfo* info);
+        
+        /* Return the size of the payload carried by this routing header */
+        virtual size_t GetRoutingPayloadSize() const;
+
+        /* Copy the raw data of the payload of this routing header */
+        virtual void FillRoutingPayload(byte *payload) const;
+
+        static const byte FieldNextHeader = 0;
+        static const byte FieldHeaderExtLen = 1;
+        static const byte FieldRoutingType = 2;
+        static const byte FieldSegmentLeft = 3;
+    
+    public:
+
+        static const word PROTO = 0x2b00;
+
+        IPv6RoutingHeaderLayer(const size_t &hdr_size=4,
+                               const char *layer_name="IPv6RoutingHeaderLayer",
+                               const word &proto_id=0x2b00,
+                               const bool &reset_fields=true);
+
+        IPv6RoutingHeaderLayer(const IPv6RoutingHeaderLayer &other)
+            : Layer(other) {}
+
+        IPv6RoutingHeaderLayer& operator=(const IPv6RoutingHeaderLayer &right) {
+            Layer::operator=(right);
+            return *this;
+        }
+
+        Layer& operator=(const Layer &right) {
+            if (GetName() != right.GetName())
+				throw std::runtime_error("Cannot convert " + right.GetName() + " to " + GetName());
+			return IPv6RoutingHeaderLayer::operator=(dynamic_cast<const IPv6RoutingHeaderLayer&>(right));
+        }
+
+        void SetNextHeader(const byte& value) {
+            SetFieldValue(FieldNextHeader,value);
+        };
+
+        void SetHeaderExtLen(const byte& value) {
+            SetFieldValue(FieldHeaderExtLen,value);
+        };
+
+        void SetRoutingType(const byte& value) {
+            SetFieldValue(FieldRoutingType,value);
+        };
+
+        void SetSegmentLeft(const byte& value) {
+            SetFieldValue(FieldSegmentLeft,value);
+        };
+
+        byte  GetNextHeader() const {
+            return GetFieldValue<byte>(FieldNextHeader);
+        };
+
+        byte  GetHeaderExtLen() const {
+            return GetFieldValue<byte>(FieldHeaderExtLen);
+        };
+
+        byte  GetRoutingType() const {
+            return GetFieldValue<byte>(FieldRoutingType);
+        };
+
+        byte  GetSegmentLeft() const {
+            return GetFieldValue<byte>(FieldSegmentLeft);
+        };
+
+        /* Build IPv6RoutingHeader layer from type */
+        static IPv6RoutingHeaderLayer* Build(int type);
+
+        ~IPv6RoutingHeaderLayer() { /* Destructor */ };
+
+    };
+
+}
+
+#endif /* IPV6ROUTINGHEADERLAYER_H_ */

--- a/libcrafter/crafter/Protocols/IPv6RoutingHeaderLayerConstructor.cpp
+++ b/libcrafter/crafter/Protocols/IPv6RoutingHeaderLayerConstructor.cpp
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2015, Olivier Tilmans
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL OLIVIER TILMANS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "IPv6RoutingHeaderLayer.h"
+
+using namespace Crafter;
+using namespace std;
+
+IPv6RoutingHeaderLayer::IPv6RoutingHeaderLayer(const size_t &hdr_size,
+        const char *layer_name, const word &proto_id, const bool &reset_fields) {
+
+    allocate_bytes(hdr_size);
+    SetName(layer_name);
+    SetprotoID(proto_id);
+    DefineProtocol();
+
+    SetDefaultValues();
+
+    if (reset_fields)
+        ResetFields();
+}
+
+void IPv6RoutingHeaderLayer::DefineProtocol() {
+    Fields.push_back(new ByteField("NextHeader",0,0));
+    Fields.push_back(new ByteField("HeaderExtLen",0,1));
+    Fields.push_back(new ByteField("RoutingType",0,2));
+    Fields.push_back(new ByteField("SegmentLeft",0,3));
+}
+
+void IPv6RoutingHeaderLayer::SetDefaultValues() {
+    SetNextHeader(0);
+    SetHeaderExtLen(0);
+    SetRoutingType(0);
+    SetSegmentLeft(0);
+}

--- a/libcrafter/crafter/Protocols/IPv6RoutingHeaderLayerCraft.cpp
+++ b/libcrafter/crafter/Protocols/IPv6RoutingHeaderLayerCraft.cpp
@@ -1,0 +1,94 @@
+/*
+Copyright (c) 2015, Olivier Tilmans
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL OLIVIER TILMANS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "IPv6RoutingHeaderLayer.h"
+#include "IPv6SegmentRoutingHeader.h"
+#include "IPv6.h"
+
+
+using namespace Crafter;
+using namespace std;
+
+
+IPv6RoutingHeaderLayer* IPv6RoutingHeaderLayer::Build(int type) {
+    switch(type) {
+        case 0: /* Routing Header Type 0 -- DEPRECATED */
+        case 1: /* Nimrod -- DEPRECATED 2009-05-06 */
+        case 2: /* IPv6 mobility -- rfc6275 */
+        case 3: /* RPL -- rfc6554 */
+            /* Not implemented :( */
+            return new IPv6RoutingHeaderLayer;
+        case 4: /* Segment Routing -- draft-previdi-6man-segment-routing-header */
+            return new IPv6SegmentRoutingHeader;
+        case 253: /* IETF Experimental values -- rfc4727 */
+        case 254: /* IETF Experimental values -- rfc4727 */
+            return new IPv6RoutingHeaderLayer;
+    }
+    /* Defaulting to an opaque layer */
+    return new IPv6RoutingHeaderLayer;
+}
+
+size_t IPv6RoutingHeaderLayer::GetRoutingPayloadSize() const {
+    /* Everything in type data + the required _unused_ 4 bytes of the header
+     * that will change depending on the ehader type */
+    return GetHeaderExtLen() * 8 + 4;
+}
+
+void IPv6RoutingHeaderLayer::FillRoutingPayload(byte *payload) const {
+    /* Nothing to put in the payload, just nullify it */
+    memset(payload, 0, GetRoutingPayloadSize());
+}
+
+void IPv6RoutingHeaderLayer::Craft() {
+    /* Skipping HdrExtLen, SegmentsLeft and Type because these have sane default
+     * for an opaque header: 0, 0 and a deprecated value.
+     */
+    if (TopLayer) {
+        if (!IsFieldSet(FieldNextHeader)) {
+            SetNextHeader(IPv6::GetIPv6NextHeader(TopLayer->GetID()));	
+            ResetField(FieldNextHeader);
+        }
+        else { 
+            PrintMessage(Crafter::PrintCodes::PrintWarning,
+                "IPv6RoutingHeader::Craft()", "No transport layer protocol.");
+        }
+    }     
+    size_t payload_size = GetRoutingPayloadSize();
+    byte* raw_payload = new byte[payload_size];
+    FillRoutingPayload(raw_payload);
+
+    SetPayload(raw_payload, payload_size); 
+}
+
+void IPv6RoutingHeaderLayer::ParseLayerData(ParseInfo *info) {
+    Craft();
+    /* We only need to worry about the payload, as ParseData will already have
+     * incremented the offset by the size of the fixed header. */
+    info->offset += GetRoutingPayloadSize();
+    info->next_layer = IPv6::GetNextLayer(info, GetNextHeader());
+}
+

--- a/libcrafter/crafter/Protocols/IPv6SegmentRoutingHeader.h
+++ b/libcrafter/crafter/Protocols/IPv6SegmentRoutingHeader.h
@@ -1,0 +1,237 @@
+/*
+Copyright (c) 2015, Olivier Tilmans
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL OLIVIER TILMANS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef IPV6SEGMENTROUTINGHEADER_H_
+#define IPV6SEGMENTROUTINGHEADER_H_
+
+#include "../Layer.h"
+#include "IPv6RoutingHeaderLayer.h"
+
+namespace Crafter {
+
+    class IPv6SegmentRoutingHeader: public IPv6RoutingHeaderLayer {
+ 
+        Constructor GetConstructor() const {
+            return IPv6SegmentRoutingHeader::IPv6SegmentRoutingHeaderConstFunc;
+        };
+
+        static Layer* IPv6SegmentRoutingHeaderConstFunc() {
+            return new IPv6SegmentRoutingHeader;
+        };
+
+        void Craft();
+
+        void DefineProtocol();
+
+        void SetDefaultValues();
+
+        void ParseLayerData(ParseInfo* info);
+
+        void ParsePolicy(const byte &policy_val, const byte &policy_index,
+                byte const **segment_end);
+
+        void PrintPayload(std::ostream& str) const;
+
+        byte* AllocateSegment() const;
+
+        /* Generic routing header has fields 0-3  */
+        static const byte FieldFirstSegment = 4;
+        static const byte FieldCFlag = 5;
+        static const byte FieldPFlag = 6;
+        static const byte FieldReserved = 7;
+        static const byte FieldPolicyFlag1 = 8;
+        static const byte FieldPolicyFlag2 = 9;
+        static const byte FieldPolicyFlag3 = 10;
+        static const byte FieldPolicyFlag4 = 11;
+        static const byte FieldHMACKeyID = 12;
+   
+    protected:
+
+        size_t GetRoutingPayloadSize() const;
+
+        void FillRoutingPayload(byte *payload) const;
+
+    public:
+
+        static const word PROTO = 0x2b04;
+
+        IPv6SegmentRoutingHeader();
+
+        IPv6SegmentRoutingHeader(const IPv6SegmentRoutingHeader& srh)
+            : IPv6RoutingHeaderLayer(srh),
+            Segments(srh.Segments) {
+            memcpy(PolicyList, srh.PolicyList, sizeof(PolicyList));
+            memcpy(HMAC, srh.HMAC, sizeof(HMAC));
+        };
+
+		/* Assignment operator of this class */
+		IPv6SegmentRoutingHeader& operator=(const IPv6SegmentRoutingHeader& right) {
+			/* Copy the particular data of this class */
+            Segments = right.Segments;
+            memcpy(HMAC, right.HMAC, sizeof(HMAC));
+            memcpy(PolicyList, right.PolicyList, sizeof(PolicyList));
+            /* Call the assignment operator of the base class */
+			IPv6RoutingHeaderLayer::operator=(right);
+			/* Return */
+			return *this;
+		}
+
+		Layer& operator=(const Layer& right) {
+			if (GetName() != right.GetName())
+				throw std::runtime_error("Cannot convert " 
+                        + right.GetName() + " to " + GetName());
+			return IPv6SegmentRoutingHeader::operator=(
+                    dynamic_cast<const IPv6SegmentRoutingHeader&>(right));
+		}
+
+
+        static const size_t SEGMENT_SIZE = sizeof(in6_addr);
+        struct SRPolicy {
+            static const byte SRPOLICY_UNSET = 0x0;
+            static const byte SRPOLICY_INGRESS = 0x1;
+            static const byte SRPOLICY_EGRESS = 0x2;
+            static const byte SRPOLICY_SOURCE_ADDRESS = 0x3;
+
+            /* Policies are 128bits long, opaque values, size of a segment */
+            static const size_t SRPOLICY_SIZE = IPv6SegmentRoutingHeader::SEGMENT_SIZE;
+            byte policy[SRPOLICY_SIZE];
+            byte type;
+
+            void SetIPv6(const IPv6Address &ip) { ip.Write(policy); }
+            size_t GetSize() const { return type == SRPOLICY_UNSET ? 0 : SRPOLICY_SIZE; }
+            void Write(byte *dst) const { memcpy(dst, policy, SRPOLICY_SIZE); }
+            void Read(const byte *src) { memcpy(policy, src, SRPOLICY_SIZE); }
+            void Print(const int& nr, std::ostream& str) const {
+                char addr[INET6_ADDRSTRLEN];
+                inet_ntop(AF_INET6, policy, addr, INET6_ADDRSTRLEN);
+                str << "Policy " << nr << " = " << addr
+                    << " (" << GetTypeDescr() << ") , ";
+            }
+            const char* GetTypeDescr() const {
+                switch(type) {
+                    case SRPOLICY_EGRESS: return "Egress router";
+                    case SRPOLICY_INGRESS: return "Ingress router";
+                    case SRPOLICY_SOURCE_ADDRESS: return "Original source address";
+                }
+                return "Unset";
+            }
+
+            SRPolicy() : type(SRPOLICY_UNSET) { memset(policy, 0, SRPOLICY_SIZE); }
+
+            static bool IsSet(byte policy_val) { return policy_val != SRPOLICY_UNSET; }
+        };
+
+        typedef struct { byte s[SEGMENT_SIZE]; } segment_t;
+
+        std::vector<segment_t> Segments;
+        SRPolicy PolicyList[4];
+        /* HMAC is 256b */
+        byte HMAC[32];
+        static const size_t HMAC_SIZE = sizeof(HMAC);
+
+        void SetFirstSegment(const byte& value) {
+            SetFieldValue(FieldFirstSegment,value);
+        };
+
+        void SetCFlag(const word& value) {
+            SetFieldValue(FieldCFlag,value);
+        };
+
+        void SetPFlag(const word& value) {
+            SetFieldValue(FieldPFlag,value);
+        };
+
+        void SetReserved(const word& value) {
+            SetFieldValue(FieldReserved,value);
+        };
+
+        void SetPolicyFlag1(const word& value) {
+            SetFieldValue(FieldPolicyFlag1,value);
+        };
+
+        void SetPolicyFlag2(const word& value) {
+            SetFieldValue(FieldPolicyFlag2,value);
+        };
+
+        void SetPolicyFlag3(const word& value) {
+            SetFieldValue(FieldPolicyFlag3,value);
+        };
+
+        void SetPolicyFlag4(const word& value) {
+            SetFieldValue(FieldPolicyFlag4,value);
+        };
+
+        void SetHMACKeyID(const byte& value) {
+            SetFieldValue(FieldHMACKeyID,value);
+        };
+
+        byte  GetFirstSegment() const {
+            return GetFieldValue<byte>(FieldFirstSegment);
+        };
+
+        word  GetCFlag() const {
+            return GetFieldValue<word>(FieldCFlag);
+        };
+
+        word  GetPFlag() const {
+            return GetFieldValue<word>(FieldPFlag);
+        };
+
+        word  GetReserved() const {
+            return GetFieldValue<word>(FieldReserved);
+        };
+
+        word  GetPolicyFlag1() const {
+            return GetFieldValue<word>(FieldPolicyFlag1);
+        };
+
+        word  GetPolicyFlag2() const {
+            return GetFieldValue<word>(FieldPolicyFlag2);
+        };
+
+        word  GetPolicyFlag3() const {
+            return GetFieldValue<word>(FieldPolicyFlag3);
+        };
+
+        word  GetPolicyFlag4() const {
+            return GetFieldValue<word>(FieldPolicyFlag4);
+        };
+
+        byte  GetHMACKeyID() const {
+            return GetFieldValue<byte>(FieldHMACKeyID);
+        };
+
+        ~IPv6SegmentRoutingHeader();
+
+        void PushIPv6Segment(const std::string& ip);
+
+        void CopySegment(const byte *segment_start);
+
+    };
+
+}
+
+#endif /* IPV6SEGMENTROUTINGHEADER_H_ */

--- a/libcrafter/crafter/Protocols/IPv6SegmentRoutingHeaderConstructor.cpp
+++ b/libcrafter/crafter/Protocols/IPv6SegmentRoutingHeaderConstructor.cpp
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2015, Olivier Tilmans
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL OLIVIER TILMANS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "IPv6SegmentRoutingHeader.h"
+
+using namespace Crafter;
+using namespace std;
+
+IPv6SegmentRoutingHeader::IPv6SegmentRoutingHeader() 
+    : IPv6RoutingHeaderLayer(8, "IPv6SegmentRoutingHeader", 0x2b04, false) {
+    memset(HMAC, 0, HMAC_SIZE);
+    memset(PolicyList, 0, sizeof(PolicyList));
+    DefineProtocol();
+    SetDefaultValues();
+    ResetFields();
+}
+
+void IPv6SegmentRoutingHeader::DefineProtocol() {
+    Fields.push_back(new ByteField("FirstSegment",1,0));
+    Fields.push_back(new BitFlag<8>("CFlag",1,"Cleanup","Keep"));
+    Fields.push_back(new BitFlag<9>("PFlag",1,"Protected","NoFRR"));
+    Fields.push_back(new BitsField<2,10>("Reserved",1));
+    Fields.push_back(new BitsField<3,12>("PolicyFlag1",1));
+    Fields.push_back(new BitsField<3,15>("PolicyFlag2",1));
+    Fields.push_back(new BitsField<3,18>("PolicyFlag3",1));
+    Fields.push_back(new BitsField<3,21>("PolicyFlag4",1));
+    Fields.push_back(new ByteField("HMACKeyID",1,3));
+}
+
+void IPv6SegmentRoutingHeader::SetDefaultValues() {
+    SetRoutingType(4);
+    SetFirstSegment(0);
+    SetCFlag(0);
+    SetPFlag(0);
+    SetReserved(0);
+    SetPolicyFlag1(0);
+    SetPolicyFlag2(0);
+    SetPolicyFlag3(0);
+    SetPolicyFlag4(0);
+    SetHMACKeyID(0);
+}
+
+IPv6SegmentRoutingHeader::~IPv6SegmentRoutingHeader() {
+    vector<segment_t>::const_iterator it;
+    //for (it = Segments.begin(); it != Segments.end(); ++it)
+    //    delete *it;
+}

--- a/libcrafter/crafter/Protocols/IPv6SegmentRoutingHeaderCraft.cpp
+++ b/libcrafter/crafter/Protocols/IPv6SegmentRoutingHeaderCraft.cpp
@@ -1,0 +1,227 @@
+/*
+Copyright (c) 2015, Olivier Tilmans
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL OLIVIER TILMANS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "IPv6SegmentRoutingHeader.h"
+
+using namespace Crafter;
+using namespace std;
+
+
+size_t IPv6SegmentRoutingHeader::GetRoutingPayloadSize() const {
+    /* Check if we don't already know the header length */
+    size_t s = GetHeaderExtLen() * 8;
+    if (s)
+        return s;
+
+    /* Base payload size is sum of segments size */
+    s = Segments.size() * SEGMENT_SIZE;
+
+    /* Check if we have some policy addresses set */ 
+    if (SRPolicy::IsSet(GetPolicyFlag1()))
+        s += SRPolicy::SRPOLICY_SIZE;
+    if (SRPolicy::IsSet(GetPolicyFlag2()))
+        s += SRPolicy::SRPOLICY_SIZE;
+    if (SRPolicy::IsSet(GetPolicyFlag3()))
+        s += SRPolicy::SRPOLICY_SIZE;
+    if (SRPolicy::IsSet(GetPolicyFlag4()))
+        s += SRPolicy::SRPOLICY_SIZE;
+
+    /* HMAC field present iff HMACKeyID set */
+    if (GetHMACKeyID())
+        s += HMAC_SIZE; 
+    
+    return s;
+}
+
+void IPv6SegmentRoutingHeader::FillRoutingPayload(byte *payload) const {
+    /* Put all segments at the start */
+    vector<segment_t>::const_iterator it;
+    for (it = Segments.begin(); it != Segments.end(); ++it, payload += SEGMENT_SIZE)
+        memcpy(payload, it->s, SEGMENT_SIZE);
+
+    /* Then the policy list */
+    if (SRPolicy::IsSet(GetPolicyFlag1())) {
+        PolicyList[0].Write(payload);
+        payload += SRPolicy::SRPOLICY_SIZE;
+    }
+    if (SRPolicy::IsSet(GetPolicyFlag2())) {
+        PolicyList[1].Write(payload);
+        payload += SRPolicy::SRPOLICY_SIZE;
+    }
+    if (SRPolicy::IsSet(GetPolicyFlag3())) {
+        PolicyList[2].Write(payload);
+        payload += SRPolicy::SRPOLICY_SIZE;
+    }
+    if (SRPolicy::IsSet(GetPolicyFlag4())) {
+        PolicyList[3].Write(payload);
+        payload += SRPolicy::SRPOLICY_SIZE;
+    }
+
+    /* Then the HMAC */
+    if (GetHMACKeyID()) {
+        memcpy(payload, HMAC, HMAC_SIZE);
+        payload += HMAC_SIZE;
+    }
+}
+
+void IPv6SegmentRoutingHeader::Craft() {
+    /* Segment Routing has (will have) type 4 */
+    if (!IsFieldSet(FieldRoutingType)) {
+        SetRoutingType(4);
+        ResetField(FieldRoutingType);
+    }
+
+    /* By default, segment left will point to the segment on top of the stack,
+     * thus the first one in the segment routed path */
+    if (!IsFieldSet(FieldSegmentLeft)) {
+        SetSegmentLeft(Segments.size() - 1);
+        ResetField(FieldSegmentLeft);
+    }
+    
+    /* Fill in policy flags if some have been set */
+    byte policy_val = PolicyList[0].type;
+    if (SRPolicy::IsSet(policy_val)) {
+        SetPolicyFlag1(policy_val);
+        ResetField(FieldPolicyFlag1);
+    }
+    policy_val = PolicyList[1].type;
+    if (SRPolicy::IsSet(policy_val)) {
+        SetPolicyFlag2(policy_val);
+        ResetField(FieldPolicyFlag2);
+    }
+    policy_val = PolicyList[2].type;
+    if (SRPolicy::IsSet(policy_val)) {
+        SetPolicyFlag3(policy_val);
+        ResetField(FieldPolicyFlag3);
+    }
+    policy_val = PolicyList[3].type;
+    if (SRPolicy::IsSet(policy_val)) {
+        SetPolicyFlag4(policy_val);
+        ResetField(FieldPolicyFlag4);
+    
+    }
+
+    /* Extension header length is the number of groups of 8 bytes
+     * after the first 8 bytes of the header,
+     * which is only the payload in this case*/
+    if (!IsFieldSet(FieldHeaderExtLen)) {
+        SetHeaderExtLen(GetRoutingPayloadSize() / 8);
+        ResetField(FieldHeaderExtLen);
+    }
+
+    /* Super class will take care of registering the payload and next header */
+    IPv6RoutingHeaderLayer::Craft();
+}
+
+void IPv6SegmentRoutingHeader::ParsePolicy(const byte &policy_val,
+        const byte &policy_index, byte const **segment_end) {
+    /* Check if that policy is set*/
+    if (SRPolicy::IsSet(policy_val)) {
+        SRPolicy& policy = PolicyList[policy_index];
+        /* Update the pointer towards the end of the segment section */ 
+        *segment_end -= SRPolicy::SRPOLICY_SIZE; 
+        /* Copy its type */
+        policy.type = policy_val;
+        /* Copy its value */
+        policy.Read(*segment_end);
+    }
+}
+
+void IPv6SegmentRoutingHeader::PushIPv6Segment(const string& ip) {
+    segment_t segment;
+    /* Convert the ip to bytes */
+    inet_pton(AF_INET6, ip.c_str(), segment.s);
+    /* Push it on the segment stack */
+    Segments.push_back(segment);
+}
+
+void IPv6SegmentRoutingHeader::CopySegment(const byte *segment_start) {
+    /* Allocate a buffer to store the IPv6 address */
+    segment_t segment;
+    /* Copy it */
+    memcpy(segment.s, segment_start, SEGMENT_SIZE);
+    /* Put it on the segments stack */
+    Segments.push_back(segment);
+}
+
+void IPv6SegmentRoutingHeader::ParseLayerData(ParseInfo* info) {
+    /* SRH is structured as FixedHeader/Segments/PolicyList/HMAC ,
+     * where the last two part are optional */
+    const byte *segment_start = info->raw_data + info->offset;
+    const byte *segment_end = segment_start + GetHeaderExtLen() * 8;
+    
+    /* Check presence of the HMAC field at the end*/
+    if (GetHMACKeyID()) {
+        /* Update the pointer to the end of the segment section */
+        segment_end -= HMAC_SIZE;
+        /* Copy the HMAC field */
+        memcpy(HMAC, segment_end, HMAC_SIZE);
+    }
+    
+    /* Check, starting at the last one, for the presence of Policy data */
+    ParsePolicy(GetPolicyFlag4(), 3, &segment_end);
+    ParsePolicy(GetPolicyFlag3(), 2, &segment_end);
+    ParsePolicy(GetPolicyFlag2(), 1, &segment_end);
+    ParsePolicy(GetPolicyFlag1(), 0, &segment_end);
+
+    /* Finally parse all segments that are left */
+    for (; segment_start < segment_end; segment_start += SEGMENT_SIZE)
+        CopySegment(segment_start);
+
+    /* We've processed the SR part of the header,
+     * delegate the generic handling to the super class */
+    IPv6RoutingHeaderLayer::ParseLayerData(info);
+}
+
+void IPv6SegmentRoutingHeader::PrintPayload(ostream& str) const {
+    str << "Segment stack = [ ";
+    vector<segment_t>::const_iterator it;
+    for (it = Segments.begin(); it != Segments.end(); ++it) {
+        char addr[INET6_ADDRSTRLEN];
+        inet_ntop(AF_INET6, it->s, addr, INET6_ADDRSTRLEN);
+        str << addr << " , ";
+    }
+    str << "], ";
+    if (SRPolicy::IsSet(GetPolicyFlag1()))
+        PolicyList[0].Print(1, str);
+    if (SRPolicy::IsSet(GetPolicyFlag2()))
+        PolicyList[1].Print(2, str);
+    if (SRPolicy::IsSet(GetPolicyFlag3()))
+        PolicyList[2].Print(3, str);
+    if (SRPolicy::IsSet(GetPolicyFlag1()))
+        PolicyList[3].Print(4, str);
+    if (GetHMACKeyID()) {
+        str << "HMAC = ";
+        str << hex;
+        for (size_t i = 0; i < HMAC_SIZE; ++i) {
+            if (!(i % 8)) str << " 0x"; 
+            str << (int)HMAC[i];
+        }
+        str << dec << " ";
+    }
+}
+


### PR DESCRIPTION
This patch adds the support for:
- The IPv6 Routing header as an 'abstract' type (header 43)
- The IPv6 Segment Routing one (currently with routing type 4, https://datatracker.ietf.org/doc/draft-previdi-6man-segment-routing-header/ )

Feel free to request changes if needed.
I will implement the other non-deprecated types (rpl / ipv6 mobility) once the 'base' implementation of the routing header is merged.