### PR TITLE
Bithandling: check if ntohll/... is defined as a macro

### DIFF
--- a/libcrafter/crafter/Utils/BitHandling.cpp
+++ b/libcrafter/crafter/Utils/BitHandling.cpp
@@ -98,6 +98,7 @@ word Crafter::ClearComplementRange(word value, byte ibit, byte ebit) {
 	return value;
 }
 
+#ifndef htonll
 uint64_t Crafter::htonll(uint64_t value) {
 	static const int num = 42;
 
@@ -108,7 +109,10 @@ uint64_t Crafter::htonll(uint64_t value) {
 	}
 	return value;
 }
+#endif
 
+#ifndef ntohll
 uint64_t Crafter::ntohll(uint64_t value) {
 	return htonll(value);
 }
+#endif

--- a/libcrafter/crafter/Utils/BitHandling.h
+++ b/libcrafter/crafter/Utils/BitHandling.h
@@ -66,9 +66,13 @@ namespace Crafter {
 	/* Clear all bits except the range specified */
 	word ClearComplementRange(word value, byte ibit, byte ebit);
 
+#ifndef htonll
 	uint64_t htonll(uint64_t value);
+#endif
 
+#ifndef nothll
 	uint64_t ntohll(uint64_t value);
+#endif
 
 }
 


### PR DESCRIPTION
OSX 10.10 defines macros for ntohll/htonll (as exhibited in https://github.com/tracebox/tracebox/issues/17).