### PR TITLE
Sendrecv

### DIFF
--- a/libcrafter/crafter/Packet.h
+++ b/libcrafter/crafter/Packet.h
@@ -157,6 +157,7 @@ namespace Crafter {
 		Packet* SocketSendRecv(int sd, const std::string& iface = "",double timeout = 1, int retry = 3, const std::string& user_filter = " ");
 		template<class Pointer>
 		void SocketSendRecvPtr(int sd, const std::string& iface, double timeout, int retry, const std::string& user_filter, Pointer& ptr);
+		void GetFilter(std::stringstream& out) const;
 
 		/* Print each layer of the packet */
 		void Print(std::ostream& str) const;


### PR DESCRIPTION
the libpcap read timeout (to_ms), is the number of ms during
which read calls should be delayed, to be able to batch successive
packets (e.g. be more efficient if we want to capture a large number
of packets).
In this case, we only care about the response, so it is set to 1ms
(0 would block indefinitely -- until the OS receive buffer is full
which is likely to never happen in our case), and we explicitely
set the immediate_mode.

As for the timeout handling, we simply fallback on using select()

Overall this yields much better performance when chaining mutliple sendrecv calls, as these will return
as soon as a packet is receive (instead of waiting for timeout expiratoin every time).