### PR TITLE
Fix: pcap_set_immediate_mode is not defined

### DIFF
--- a/libcrafter/configure.ac
+++ b/libcrafter/configure.ac
@@ -62,7 +62,9 @@ AC_ARG_WITH(libpcap,
 )
 AC_SUBST(PCAPINC)
 AC_SUBST(PCAPLIB)
-
+AC_CHECK_LIB([pcap], [pcap_set_immediate_mode],
+      [AC_DEFINE([HAVE_PCAP_SET_IMMEDIATE_MODE], [1],
+         [Define to 1 if pcap_set_immediate_mode is defined])])
 AC_CHECK_LIB(pthread, pthread_create)
 AC_CHECK_LIB(rt,clock_gettime)
 

--- a/libcrafter/crafter/Packet.cpp
+++ b/libcrafter/crafter/Packet.cpp
@@ -27,6 +27,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <sstream>
 
+#include "config.h"
+
 #include "Packet.h"
 #include "Crafter.h"
 #include "Utils/RawSocket.h"
@@ -530,8 +532,9 @@ Packet* Packet::SocketSendRecv(int raw, const string& iface, double timeout, int
 		        				  1,  /* to_ms - amount of time to delay a read */
 									  /* 0 = sniff until error */
 				      libcap_errbuf); /* error message buffer if something goes wrong */
+#ifdef HAVE_PCAP_SET_IMMEDIATE_MODE
 	pcap_set_immediate_mode(handle, 1); /* We want the response ASAP */
-
+#endif
 	if (handle == NULL)
 	  /* There was an error */
 		throw std::runtime_error("Packet::SocketSendRecv() : Listening device " + string(libcap_errbuf));


### PR DESCRIPTION
Added an autoconf check to handle distributions where libpcap
is too old to have that call.