### PR TITLE
Code now compiles for Android NDK

### DIFF
--- a/libcrafter/configure.ac
+++ b/libcrafter/configure.ac
@@ -79,6 +79,8 @@ case "${host_os}" in
     ;;
 esac
 
+AC_CHECK_FUNCS(ether_aton_r)
+
 ## Define these substitions here to keep all version information in one place.
 ## For information on how to properly maintain the library version information,
 ## refer to the libtool manual, section "Updating library version information":

--- a/libcrafter/crafter/Fields/IPv6Address.h
+++ b/libcrafter/crafter/Fields/IPv6Address.h
@@ -33,6 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include "FieldInfo.h"
 #include <arpa/inet.h>
+#include <netinet/in.h>
 
 namespace Crafter {
 
@@ -41,8 +42,8 @@ namespace Crafter {
 		size_t nword;
 		size_t nbyte;
 		size_t offset;
-                struct sockaddr_in6 addr;
-                
+        struct sockaddr_in6 addr;
+
 		void PrintValue(std::ostream& str) const;
 
 	public:
@@ -56,7 +57,7 @@ namespace Crafter {
 		void SetField(const std::string& ip_address);
 
 		FieldInfo* Clone() const;
-                
+
                 operator byte*() {return (byte*)&addr.sin6_addr;}
 
 		virtual ~IPv6Address();

--- a/libcrafter/crafter/Fields/MACAddress.cpp
+++ b/libcrafter/crafter/Fields/MACAddress.cpp
@@ -31,11 +31,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 #include <cstdio>
 #include "MACAddress.h"
+#include "config.h"
 
 using namespace std;
 using namespace Crafter;
 
-#if __APPLE__
+#ifndef HAVE_ETHER_ATON_R
 #ifndef isdigit
 #define isdigit(c)  (c >= '0' && c <= '9')
 #endif

--- a/libcrafter/crafter/Fields/NumericFields.cpp
+++ b/libcrafter/crafter/Fields/NumericFields.cpp
@@ -29,6 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../Utils/BitHandling.h"
 
 #include <arpa/inet.h>
+#include <netinet/in.h>
 
 using namespace std;
 using namespace Crafter;

--- a/libcrafter/crafter/Protocols/DHCPOptions.cpp
+++ b/libcrafter/crafter/Protocols/DHCPOptions.cpp
@@ -396,9 +396,9 @@ void DHCPOptionsIP::SetPayload() {
 	vector<string>::const_iterator it_ip;
 	for(it_ip = ip_addresses.begin() ; it_ip != ip_addresses.end() ; it_ip++) {
 		/* Get the IP in network byte order */
-		in_addr_t bin_ip = inet_addr((*it_ip).c_str());
+		struct in_addr bin_ip = { inet_addr((*it_ip).c_str()) };
 		/* Set the payload from the string */
-		data.AddPayload((byte *)&bin_ip, sizeof(in_addr_t));
+		data.AddPayload((byte *)&bin_ip.s_addr, sizeof(bin_ip.s_addr));
 	}
 }
 

--- a/libcrafter/crafter/Protocols/DNS.h
+++ b/libcrafter/crafter/Protocols/DNS.h
@@ -32,7 +32,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <netinet/in.h>
 #include <netdb.h>
 #include <arpa/nameser.h>
+#ifdef __APPLE__
 #include <arpa/nameser_compat.h>
+#endif
 #include <resolv.h>
 
 #include "RawLayer.h"

--- a/libcrafter/crafter/Protocols/TCPOptionLayer.cpp
+++ b/libcrafter/crafter/Protocols/TCPOptionLayer.cpp
@@ -36,6 +36,28 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Crafter;
 
+#ifndef TCPOPT_EOL
+	#define TCPOPT_EOL		0
+#endif
+#ifndef TCPOPT_NOP
+	#define TCPOPT_NOP		1
+#endif
+#ifndef TCPOPT_MAXSEG
+	#define TCPOPT_MAXSEG		2
+#endif
+#ifndef TCPOPT_WINDOW
+	#define TCPOPT_WINDOW		3
+#endif
+#ifndef TCPOPT_SACK_PERMITTED
+	#define TCPOPT_SACK_PERMITTED	4		/* Experimental */
+#endif
+#ifndef TCPOPT_SACK
+	#define TCPOPT_SACK		5		/* Experimental */
+#endif
+#ifndef TCPOPT_TIMESTAMP
+	#define TCPOPT_TIMESTAMP	8
+#endif
+
 TCPOptionLayer* TCPOptionLayer::Build(int opt, ParseInfo *info) {
 
 	switch(opt) {
@@ -62,7 +84,7 @@ TCPOptionLayer* TCPOptionLayer::Build(int opt, ParseInfo *info) {
 		return new TCPOptionWindowScale;
 		break;
 	case TCPOPT_MPTCP:
-		{	
+		{
 			int subopt = (info->raw_data + info->offset)[2];
 			return TCPOptionMPTCP::Build(subopt);
 			break;

--- a/libcrafter/crafter/Utils/ARPSpoofing.cpp
+++ b/libcrafter/crafter/Utils/ARPSpoofing.cpp
@@ -34,9 +34,9 @@ using namespace Crafter;
 
 void Crafter::CleanARPContext(ARPContext* arp_context) {
 	/* Get the thread ID and cancel the spoofing */
-	pthread_t tid = arp_context->tid;
+	arp_context->keep_going = false;
 
-	int rc = pthread_cancel(tid);
+	int rc = pthread_join(arp_context->tid, NULL);
 
 	if (rc)
 		throw std::runtime_error("CleanARPContext() : Cancelating thread. Returning code = " + StrPort(rc));

--- a/libcrafter/crafter/Utils/ARPSpoofing.h
+++ b/libcrafter/crafter/Utils/ARPSpoofing.h
@@ -65,6 +65,7 @@ namespace Crafter {
 
 		/* Thread ID of the thread that is doing the spoofing */
 		pthread_t tid;
+		bool keep_going;
 
 		/* Attacker's MAC Address */
 		std::string AttackerMAC;

--- a/libcrafter/crafter/Utils/ARPSpoofingRequest.cpp
+++ b/libcrafter/crafter/Utils/ARPSpoofingRequest.cpp
@@ -85,7 +85,7 @@ void* Crafter::ARPSpoofRequest(void* thread_arg) {
 	}
 
 
-	while(1) {
+	while(context->keep_going) {
 		Send(context->arp_packets,context->iface,16);
 		sleep(5);
 	}
@@ -223,6 +223,8 @@ ARPContext* Crafter::ARPSpoofingRequest(const std::string& net_target, const std
 	context->arp_packets = arp_request;
 
 	context->SanityCheck();
+
+	context->keep_going = true;
 
 	int rc = pthread_create(&tid, NULL, ARPSpoofRequest, thread_arg);
 

--- a/libcrafter/crafter/Utils/BitHandling.cpp
+++ b/libcrafter/crafter/Utils/BitHandling.cpp
@@ -27,6 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "BitHandling.h"
 
+#include <netinet/in.h>
 #include <arpa/inet.h>
 
 using namespace std;

--- a/libcrafter/crafter/Utils/CrafterUtils.cpp
+++ b/libcrafter/crafter/Utils/CrafterUtils.cpp
@@ -426,9 +426,9 @@ vector<byte> Crafter::IPtoRawData(const vector<string>& ips) {
 	size_t raw_counter = 0;
 
 	for(it_str = ips.begin() ; it_str != ips.end() ; ++it_str) {
-		in_addr_t num_ip = inet_addr((*it_str).c_str());
+		struct in_addr num_ip = { inet_addr((*it_str).c_str()) };
 		for(size_t i = 0; i < sizeof(word) ; i++) {
-			raw_data[raw_counter] = ((byte*)&num_ip)[i];
+			raw_data[raw_counter] = ((byte*)&num_ip.s_addr)[i];
 			raw_counter++;
 		}
 	}
@@ -448,8 +448,8 @@ vector<string> Crafter::RawDatatoIP(const vector<byte>& raw_data) {
 
 	for(size_t j = 0 ; j < str_size ; j++) {
 	    struct in_addr ip_address;
-		memcpy(&ip_address.s_addr ,&raw_data[raw_counter], sizeof(in_addr_t));
-		raw_counter += sizeof(in_addr_t);
+		memcpy(&ip_address.s_addr ,&raw_data[raw_counter], sizeof(ip_address.s_addr));
+		raw_counter += sizeof(ip_address.s_addr);
 		/* Push the IP address in string format */
 		ips[j] = string(inet_ntoa(ip_address));
 	}

--- a/libcrafter/crafter/Utils/RawSocket.cpp
+++ b/libcrafter/crafter/Utils/RawSocket.cpp
@@ -31,7 +31,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fcntl.h>
 #include <net/bpf.h>
 #include <net/if_dl.h>
-#include <netinet/in.h>
 #include <net/route.h>
 #endif
 
@@ -443,7 +442,7 @@ int Crafter::SocketSender::SendSocket(int rawsock, word proto_id, byte *pkt, siz
 		struct sockaddr_in din;
 	    din.sin_family = AF_INET;
 	    din.sin_port = 0;
-	    memcpy(&din.sin_addr.s_addr,pkt + 16,sizeof(in_addr_t));
+	    memcpy(&din.sin_addr.s_addr,pkt + 16,sizeof(din.sin_addr.s_addr));
 	    memset(din.sin_zero, '\0', sizeof (din.sin_zero));
 
 	    return SendRawSocket(rawsock,(sockaddr *)&din,sizeof(din),pkt,pkt_len);

--- a/libcrafter/crafter/Utils/RawSocket.h
+++ b/libcrafter/crafter/Utils/RawSocket.h
@@ -36,6 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdio>
 #include <cstdlib>
 #include <sys/socket.h>
+#include <netinet/in.h>
 
 #ifndef __APPLE__
 #include <features.h>

--- a/libcrafter/crafter/Utils/Sniffer.cpp
+++ b/libcrafter/crafter/Utils/Sniffer.cpp
@@ -320,8 +320,7 @@ void Crafter::Sniffer::Cancel() {
 
 	if(spawned) {
 		pcap_breakloop(handle);
-		/* If the thread was spawned, call pthread_cancel for terminating the sniffing */
-		int rc = pthread_cancel(thread_id);
+		int rc = pthread_join(thread_id, NULL);
 
 		if (rc)
 			throw std::runtime_error("Sniffer::Cancel() : Cancelating thread. Returning code = " + StrPort(rc));

--- a/libcrafter/crafter/Utils/TCPConnection.cpp
+++ b/libcrafter/crafter/Utils/TCPConnection.cpp
@@ -373,7 +373,7 @@ void* Crafter::ConnectHandler(void* thread_arg) {
 	//cout << filter << endl;
 
 	/* Launch the snnifer */
-	Sniffer sniff(filter,iface,PckHand);
+	conex->sniff = new Sniffer(filter,iface,PckHand);
 
 	/* Signal the threshold... */
 	pthread_cond_signal(&conex->threshold_cv);
@@ -381,7 +381,7 @@ void* Crafter::ConnectHandler(void* thread_arg) {
 	pthread_mutex_unlock(&conex->mutex);
 
 	/* Start capturing */
-	sniff.Capture(-1,thread_arg);
+	conex->sniff->Capture(-1,thread_arg);
 
 	/* Get connection data */
 	return 0;
@@ -675,7 +675,7 @@ void TCPConnection::Close() {
 
 void TCPConnection::Reset() {
 	/* Kill the thread */
-	pthread_cancel(thread_id);
+	sniff->Cancel();
 
     pthread_mutex_lock (&mutex);
 
@@ -699,7 +699,7 @@ void TCPConnection::Reset() {
 TCPConnection::~TCPConnection() {
 	/* Close thread */
 	if(status != CLOSED) {
-		pthread_cancel(thread_id);
+		sniff->Cancel();
 	}
 
 	/* Destroy condition variable */

--- a/libcrafter/crafter/Utils/TCPConnection.h
+++ b/libcrafter/crafter/Utils/TCPConnection.h
@@ -108,6 +108,8 @@ namespace Crafter {
 		uint64_t ack;
 
 		/* ++++ Connection Data End : This data defines univocally a connection ++++ */
+		/* Sniffer used */
+		Sniffer *sniff;
 
 		/* Thread ID of the sniffer */
 		pthread_t thread_id;


### PR DESCRIPTION
Support compiling for platform rev. 15
Requires a few more files for a complete build:
- libbind for the lacking dns function in Android Bionic libc
- A proxy header pointing to sys/types.h in place of sys/bitypes.h

Changes are mainly due to
* pthread_cancel() does not exists in Bionic libc, hence the workarounds.
* in_addr_t does not exists (violating the standard), hence all the changes to struct in_addr ...
* <netinet/tcp.h> does not provide all defines

Please check that it still compiles on your machine, as I had to add some includes which should normally be present everywhere ...