### PR TITLE
Revert "No need to set a different IP length on apple"

### DIFF
--- a/libcrafter/crafter/Protocols/IPConstructor.cpp
+++ b/libcrafter/crafter/Protocols/IPConstructor.cpp
@@ -64,7 +64,12 @@ void IP::DefineProtocol() {
     Fields.push_back(new BitsField<4,4>("HeaderLength",0));
     Fields.push_back(new BitsField<6,8>("DiffServicesCP",0));
     Fields.push_back(new BitsField<2,14>("ExpCongestionNot",0));
+#ifdef __APPLE__
+	/* see http://cseweb.ucsd.edu/~braghava/notes/freebsd-sockets.txt */
+    Fields.push_back(new ShortHostNetField("TotalLength",0,2));
+#else
     Fields.push_back(new ShortField("TotalLength",0,2));
+#endif
     Fields.push_back(new XShortField("Identification",1,0));
     Fields.push_back(new BitsField<3,16>("Flags",1));
     Fields.push_back(new BitsField<13,19>("FragmentOffset",1));


### PR DESCRIPTION
This reverts commit c5224884b56d41c999b9c7da19a6f3dcf325612c.

raw socket handling in osx kernel happen here:
https://github.com/opensource-apple/xnu/blob/10.10/bsd/netinet/raw_ip.c#L429
The kernel performs additional checks on the IP datagram before
sending it, hence it needs to be in host order (and will be converted
later on).

This is related to https://github.com/tracebox/tracebox/issues/34