### PR TITLE
Fix memory leak on Layer's copy constructor.

### DIFF
--- a/libcrafter/crafter/Layer.cpp
+++ b/libcrafter/crafter/Layer.cpp
@@ -359,7 +359,7 @@ size_t Crafter::Layer::GetPayload(byte* dst) const {
 
 Crafter::Layer::Layer() : size(0), bytes_size(0), raw_data(0), BottomLayer(0), TopLayer(0) { }
 
-Crafter::Layer::Layer(const Layer& layer) {
+Crafter::Layer::Layer(const Layer& layer) : raw_data(0) {
 	/* Put size to zero */
 	size = 0;
 	/* Init bottom and top layer pointer */
@@ -404,8 +404,8 @@ Layer& Crafter::Layer::operator=(const Layer& right) {
 
 void Crafter::Layer::Clone(const Layer& layer) {
 	/* Delete memory allocated */
-	if (size)
-		delete [] raw_data;
+	delete [] raw_data;
+	raw_data = 0;
 
 	/* Put size to zero */
 	size = 0;

--- a/libcrafter/crafter/Layer.cpp
+++ b/libcrafter/crafter/Layer.cpp
@@ -371,7 +371,7 @@ Crafter::Layer::Layer(const Layer& layer) {
 	protoID = layer.protoID;
 
 	/* Equal size */
-	allocate_bytes(layer.size);
+	if(layer.size) allocate_bytes(layer.size);
 
 	/* Copy the fields from the other layer */
 	Fields = layer.Fields;
@@ -461,6 +461,5 @@ word Crafter::RNG32() {return 2 * rand(); }
 
 Crafter::Layer::~Layer() {
 	/* Delete memory allocated */
-	if (size)
-		delete [] raw_data;
+	delete [] raw_data;
 }


### PR DESCRIPTION
When copy-constructing a Layer, if the object being copied's layer sizei s 0, raw_layer is intialized by using a 0 size allocation. However, Layer::~Layer only deletes raw_layer if the size > 0. In this case,
the size is 0, so it won't ever be deleted.

This was happening specifically if you copy constructed a RawLayer, since the header size is 0. If you run it on valgrind you won't see any leaks though, since it seems like 0 size calls to operator new[]  aren't marked as leaks.

I modified Layer so it always calls delete[] on raw_data, regardless of what the size is. Moreover, it only allocates data for raw_layer on the copy constructor if the size is > 0. 