### PR TITLE
docs(readme): remove release process reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,8 +303,7 @@ expectations are documented in
 
 ## Publishing
 
-The final maintainer release checklist, including crates.io guardrails and the
-manual public upstream migration step, is in
+The final maintainer release checklist, including crates.io guardrails, is in
 [docs/operations/release.md](docs/operations/release.md).
 
 Run package-content checks before preparing a release:


### PR DESCRIPTION
## Summary
- Remove public migration/process wording from the README publishing section.
- Keep the README focused on the maintainer release checklist and crates.io guardrails.

## Validation
- `.agents/scripts/check-conventional-commits --range origin/master..HEAD`: passed
- internal release/process reference grep: no matches
- `cargo publish -p crafter --dry-run --locked`: passed
- `.agents/scripts/check-crafter-release --static`: passed