### PR TITLE
ci(release): install protobuf compiler

### DIFF
--- a/.github/workflows/local-static.yml
+++ b/.github/workflows/local-static.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends curl libpcap-dev pkg-config python3
+          sudo apt-get install -y --no-install-recommends curl libpcap-dev pkg-config protobuf-compiler python3
 
       - name: Install uv
         run: |

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends curl libpcap-dev pkg-config python3
+          sudo apt-get install -y --no-install-recommends curl libpcap-dev pkg-config protobuf-compiler python3
 
       - name: Install Rust toolchain
         run: |

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends curl libpcap-dev pkg-config python3
+          sudo apt-get install -y --no-install-recommends curl libpcap-dev pkg-config protobuf-compiler python3
 
       - name: Install Rust toolchain
         run: |


### PR DESCRIPTION
## Summary
- Install `protobuf-compiler` in hosted static, release-preparation, and publish workflows.
- Fix the publish job failure where the WHAD protobuf build script could not find `protoc`.

## Validation
- `.agents/scripts/check-conventional-commits --range origin/master..HEAD`: passed
- `cargo publish -p crafter --dry-run --locked`: passed

## Notes
- The failed publish workflow stopped before uploading the crate, before creating `v0.3.0`, and before creating the GitHub Release.