### PR TITLE
chore(crafter): prepare v0.3.1

### DIFF
--- a/.agents/scripts/prepare-crafter-release
+++ b/.agents/scripts/prepare-crafter-release
@@ -87,7 +87,10 @@ for index, line in enumerate(lines):
         continue
 
     if in_workspace_package and re.match(r"^\s*version\s*=", line):
-        match = re.match(r'^(\s*version\s*=\s*)"[^"]*"(.*)$', line)
+        # re.DOTALL keeps the trailing newline inside group(2); without it the
+        # `$` anchor stops before the line ending and the rewrite would fuse this
+        # line into the next one (version = "x"edition = "2021").
+        match = re.match(r'^(\s*version\s*=\s*)"[^"]*"(.*)$', line, re.DOTALL)
         if not match:
             raise SystemExit("workspace package version is not a quoted string")
         lines[index] = f'{match.group(1)}"{version}"{match.group(2)}'
@@ -122,7 +125,10 @@ pattern = rf"^##\s+{re.escape(version)}(?:\s|$|-)"
 if re.search(pattern, text, re.MULTILINE):
     raise SystemExit(f"CHANGELOG.md already contains version {version}")
 
-header = re.match(r"(?s)^(# .*\n\n)", text)
+# Match only the top-level title line plus its blank line. A DOTALL `.*` here is
+# greedy and backtracks to the LAST blank line in the file, which would splice
+# the new section into the previous release instead of above it.
+header = re.match(r"^(# [^\n]*\n\n)", text)
 if not header:
     raise SystemExit("CHANGELOG.md must start with a level-1 heading followed by a blank line")
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.1 - 2026-06-24
+
+### Changed
+
+- Add cleartext MQTT 3.1.1 and 5.0 coverage over TCP/1883: typed builders and decode for the baseline control packets, MQTT 5.0 properties and reason codes, QoS flows, topic aliases, retained PUBLISH and last-will helpers, stacked TCP-payload decode, the dry-run-default mqtt_session example, oracle cross-validation, CI corpus/pcap parity, and a dry-run-default mqtt-smoke probe path.
+- Extend the feature-gated whad dongle backend with dry-run-default IEEE 802.15.4 dot15d4 sniff and inject workflows.
+
 ## 0.3.0 - Packet-Level Network Interaction
 
 This is the first public release of the Rust packet-level network interaction

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["target/package-self-test"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.78"
 description = "Packet-level network interaction for Rust tools and agents."


### PR DESCRIPTION
## Summary

- Bump the `crafter` workspace to **v0.3.1** and add the 0.3.1 CHANGELOG entry.
- Headline change since 0.3.0: full cleartext **MQTT 3.1.1 + 5.0** coverage; plus the feature-gated `whad` IEEE 802.15.4 (`dot15d4`) dongle backend.

## Release-tooling fix (bundled)

The `prepare-release` automation could not produce this bump: `.agents/scripts/prepare-crafter-release` had two latent regex bugs (0.3.0 was the first release, so the bump path was never exercised):

1. **Version bump dropped the trailing newline** — `(.*)$` matched before the line's `\n` without capturing it, fusing `version = "0.3.1"edition = "2021"` and breaking `cargo` (this is why the first `prepare-release` dispatch failed at `cargo generate-lockfile`).
2. **CHANGELOG section inserted in the wrong place** — a greedy `(?s)^(# .*\n\n)` header match backtracked to the last blank line, splicing the new entry inside the previous release.

Both are fixed in `fix(release): correct version bump and changelog insertion in prepare script`, and the metadata commit here was generated by the now-fixed script.

## Validation

- `cargo verify-project`: `{"success":"true"}`
- Bump verified: `Cargo.toml` → `version = "0.3.1"` with the manifest intact; CHANGELOG `## 0.3.1` section lands at the top.
- Full `commit-policy` / `local-static` / `wire` CI runs on this PR.

## Notes

- This PR does not publish. Publishing is the separate, maintainer-gated `publish-crate` workflow (actor `pellegre` + `crates-io` environment approval).
