### PR TITLE
chore(release): prepare crafter 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.3.2 - 2026-06-27
+
+### Changed
+
+- Add SNMP packet-layer coverage with BER, PDU, v1/v2c/v3 message builders, UDP binding, examples, fixtures, oracle suites, and dry-run probe coverage.
+- Add QUIC packet-layer coverage with invariant/long/short headers, frame sequences, transport parameters, initial protection helpers, datagram/stateless-reset support, fixtures, and oracle/probe coverage.
+- Add DHCPv6 packet-layer coverage with client and relay messages, option registries, DUID/IA helpers, examples, fixtures, oracle/probe coverage, and guarded live dry-run planning.
+- Split DHCPv4 into versioned public modules, keep UDP helper compatibility, expand reply matching filters, and update guides/reference docs for the release.
+
 ## 0.3.1 - 2026-06-24
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["target/package-self-test"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.78"
 description = "Packet-level network interaction for Rust tools and agents."


### PR DESCRIPTION
- Bump the workspace `crafter` package metadata from `0.3.1` to `0.3.2`.
- Add the `0.3.2` changelog entry covering SNMP, QUIC, DHCPv6, DHCPv4 namespace cleanup, reply matching, and release docs updates.
- Validation: `.agents/scripts/check-crafter-release --static` passed.
- Validation: `cargo publish -p crafter --dry-run --locked` passed and packaged 787 files, 9.8MiB (1.8MiB compressed).
- Crates.io preflight: `https://crates.io/api/v1/crates/crafter/0.3.2` returned `404` before publishing.