### PR TITLE
chore(release): prepare crafter 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.3.3 - 2026-07-03
+
+### Changed
+
+- Add TLS packet-layer coverage with record and handshake layers, ClientHello/ServerHello builders, the TLS 1.3 extension registry, alert/heartbeat/application-data/change-cipher-spec bodies, fragmented-handshake preservation, malformed-input decode, golden fixtures, and oracle/probe coverage.
+- Add SSDP packet-layer coverage with M-SEARCH, NOTIFY, and search-response builders over UDP/1900, header decode, fixtures, and oracle/probe coverage.
+- Add NTP packet-layer coverage with v3/v4 headers, SNTP compatibility, NTS and autokey extension fields, legacy MAC tails, timestamp and fixed-point helpers, fixtures, and oracle/probe coverage.
+- Add mDNS packet-layer coverage with Bonjour record builders, known-answer and goodbye-announcement helpers, UDP/5353 decode, fixtures, and oracle/probe coverage.
+- Add disposable endpoint and appliance provider substrate with VirtualBox appliance groups, SSH docker-host and local substrate plans, readiness checks, and asset-profile environments for provider-backed live packet work.
+
 ## 0.3.2 - 2026-06-27
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["target/package-self-test"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.78"
 description = "Packet-level network interaction for Rust tools and agents."


### PR DESCRIPTION
## Summary

- Prepare crafter v0.3.3 release metadata.
- Bump `[workspace.package].version` to 0.3.3 and add the CHANGELOG section.
- Update Cargo.toml and CHANGELOG.md only.

## Changelog

- Add TLS packet-layer coverage (record + handshake layers, ClientHello/ServerHello, TLS 1.3 extension registry, alert/heartbeat/app-data bodies, fixtures, oracle/probe).
- Add SSDP packet-layer coverage over UDP/1900.
- Add NTP packet-layer coverage (v3/v4, SNTP, NTS/autokey extensions, legacy MAC).
- Add mDNS packet-layer coverage over UDP/5353.
- Add disposable endpoint/appliance provider substrate.

## Validation

- `.agents/scripts/prepare-crafter-release 0.3.3`: passed
- `.agents/scripts/check-crafter-release --static` (via prepare-release CI run 28632544763): passed

## Notes

- Prepared locally because `prepare-release.yml` aborts at its `cargo publish --dry-run` step (it runs before the metadata commit, so cargo rejects the dirty `Cargo.toml`). The release gate itself passed in that run.
- Lands via rebase-and-fast-forward admin merge.
