### PR TITLE
fix(ip): support mips fragment id atomics

### DIFF
--- a/crafter/src/wire/ip/fragment.rs
+++ b/crafter/src/wire/ip/fragment.rs
@@ -963,11 +963,12 @@ pub(super) mod ipv6_planner {
 pub(super) mod ipv6_identification {
     #![allow(dead_code)]
 
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     const IPV6_IDENTIFICATION_GAMMA: u64 = 0x9e37_79b9_7f4a_7c15;
-    static IPV6_IDENTIFICATION_AUTO_SEED: AtomicU64 = AtomicU64::new(0x243f_6a88_85a3_08d3);
+    const IPV6_IDENTIFICATION_GAMMA_LOW: u32 = IPV6_IDENTIFICATION_GAMMA as u32;
+    static IPV6_IDENTIFICATION_AUTO_SEED: AtomicU32 = AtomicU32::new(0x85a3_08d3);
 
     /// Stateful IPv6 Fragment Header Identification generator.
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1007,8 +1008,10 @@ pub(super) mod ipv6_identification {
     }
 
     fn automatic_ipv6_identification_seed() -> u64 {
-        let counter =
-            IPV6_IDENTIFICATION_AUTO_SEED.fetch_add(IPV6_IDENTIFICATION_GAMMA, Ordering::Relaxed);
+        let counter = u64::from(
+            IPV6_IDENTIFICATION_AUTO_SEED
+                .fetch_add(IPV6_IDENTIFICATION_GAMMA_LOW, Ordering::Relaxed),
+        );
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|duration| {


### PR DESCRIPTION
## Summary
- Use a 32-bit atomic counter for automatic IPv6 fragment identification seeding.
- Preserve the existing 64-bit mixed seed output while supporting targets without native 64-bit atomics.

## Validation
- `.agents/scripts/check-conventional-commits --range origin/master..HEAD`: passed
- `.agents/scripts/check-crafter-release --static`: passed

No live packet validation was run; this is an offline portability fix.