### PR TITLE
feat(net): add stateful packet sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,33 @@ Live raw sends and captures require platform privileges, and you must be
 authorized to send and capture on the target network. Keep live work off the
 developer host — provision a disposable endpoint instead.
 
+For repeated raw sends, open a reusable `PacketSender` or a raw socket
+`PacketWire` writer instead of calling the one-shot `send_packet` path in a
+loop. Dry-run planning stays offline:
+
+```rust
+use crafter::prelude::*;
+
+fn plan_many(packet: &Packet) -> Result<(), Box<dyn std::error::Error>> {
+    let mut sender = PacketSender::open(
+        SendOptions::new()
+            .iface("eth0")
+            .network_layer()
+            .dry_run(),
+    )?;
+
+    let report = sender.send(packet)?;
+    assert!(report.is_dry_run());
+    Ok(())
+}
+```
+
+Live reusable senders must choose one send class with `.link_layer()` or
+`.network_layer()` before `.live()`. A link-layer sender handles Ethernet and
+radiotap frames through one opened backend; a network-layer sender currently
+handles bare IPv4 packets. Mixed link/network traffic needs separate senders,
+and full-header IPv6 network-layer live sends remain unsupported.
+
 ## Tools: endpoint, lab, oracle, probe
 
 The live path does not have to originate from your machine. Four modules under

--- a/crafter/src/lib.rs
+++ b/crafter/src/lib.rs
@@ -157,8 +157,8 @@ pub use net::{
     send_plan, send_recv_packet, send_recv_packets, BatchSend, BatchSendEntry, BatchSendRecv,
     BatchSendRecvEntry, BatchSendRecvReport, BatchSendReport, InterfaceAddress, InterfaceInfo,
     Ipv4Range, NetError, PacketBatchSendExt, PacketBatchSendRecvExt, PacketSendExt,
-    PacketSendRecvExt, RawSender, ReplyMatcher, SendMode, SendOptions, SendPlan, SendRecv,
-    SendRecvOptions, SendRecvReport, SendReport, SendTarget, SocketSend, SocketSender,
+    PacketSendRecvExt, PacketSender, RawSender, ReplyMatcher, SendMode, SendOptions, SendPlan,
+    SendRecv, SendRecvOptions, SendRecvReport, SendReport, SendTarget, SocketSend, SocketSender,
 };
 pub use wire::Sniffer;
 pub use wire::{
@@ -218,11 +218,12 @@ pub mod prelude {
         send_packets, send_plan, send_recv_packet, send_recv_packets, BatchSend, BatchSendEntry,
         BatchSendRecv, BatchSendRecvEntry, BatchSendRecvReport, BatchSendReport, Dot11Metadata,
         InterfaceAddress, InterfaceInfo, Ipv4Range, NetError, PacketBatchSendExt,
-        PacketBatchSendRecvExt, PacketSendExt, PacketSendRecvExt, PairwiseTransientKey, Pmk,
-        RawSender, ReplyMatcher, SendMode, SendOptions, SendPlan, SendRecv, SendRecvOptions,
-        SendRecvReport, SendReport, SendTarget, Sniffer, SocketSend, SocketSender, Transmitter,
-        VecPacketSource, WifiDecryptState, WifiMetadata, WifiProtectionStatus, WireError, WpaAkm,
-        WpaCipher, WpaCredentialStatus, WpaDecrypt, WpaDecryptConfig, WpaDecryptReason,
+        PacketBatchSendRecvExt, PacketSendExt, PacketSendRecvExt, PacketSender,
+        PairwiseTransientKey, Pmk, RawSender, ReplyMatcher, SendMode, SendOptions, SendPlan,
+        SendRecv, SendRecvOptions, SendRecvReport, SendReport, SendTarget, Sniffer, SocketSend,
+        SocketSender, Transmitter, VecPacketSource, WifiDecryptState, WifiMetadata,
+        WifiProtectionStatus, WireError, WpaAkm, WpaCipher, WpaCredentialStatus, WpaDecrypt,
+        WpaDecryptConfig, WpaDecryptReason,
         WpaHandshakeStatus, WpaKeyKind, WpaMetadata, WpaNetwork, WriteReport,
     };
     pub use crate::{

--- a/crafter/src/lib.rs
+++ b/crafter/src/lib.rs
@@ -223,8 +223,8 @@ pub mod prelude {
         SendRecv, SendRecvOptions, SendRecvReport, SendReport, SendTarget, Sniffer, SocketSend,
         SocketSender, Transmitter, VecPacketSource, WifiDecryptState, WifiMetadata,
         WifiProtectionStatus, WireError, WpaAkm, WpaCipher, WpaCredentialStatus, WpaDecrypt,
-        WpaDecryptConfig, WpaDecryptReason,
-        WpaHandshakeStatus, WpaKeyKind, WpaMetadata, WpaNetwork, WriteReport,
+        WpaDecryptConfig, WpaDecryptReason, WpaHandshakeStatus, WpaKeyKind, WpaMetadata,
+        WpaNetwork, WriteReport,
     };
     pub use crate::{
         BackendKind, BluetoothMetadata, Dot15d4Metadata, DropAllTransform, DuplicateTransform,

--- a/crafter/src/net/batch.rs
+++ b/crafter/src/net/batch.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use crate::Packet;
 
 use super::error::Result;
+use super::packet_sender::{BackendPacketSender, PnetBackend, PnetIoBackend};
 use super::send::{send_packet, SendMode, SendOptions, SendReport};
 use super::send_recv::SendRecv;
 pub use super::send_recv::{
@@ -129,17 +130,68 @@ impl BatchSend {
 
     /// Send every packet and return reports aligned with the request order.
     pub fn send_all(&self, packets: &[Packet]) -> Result<BatchSendReport> {
+        self.send_all_with_pnet_backend(packets, PnetIoBackend)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn send_all_with_backend<B>(
+        &self,
+        packets: &[Packet],
+        backend: B,
+    ) -> Result<BatchSendReport>
+    where
+        B: PnetBackend,
+    {
+        self.send_all_with_pnet_backend(packets, backend)
+    }
+
+    fn send_all_with_pnet_backend<B>(
+        &self,
+        packets: &[Packet],
+        backend: B,
+    ) -> Result<BatchSendReport>
+    where
+        B: PnetBackend,
+    {
         let mut entries = (0..packets.len())
             .map(BatchSendEntry::new)
             .collect::<Vec<_>>();
+
+        if self.send_options.is_dry_run() {
+            self.collect_send_reports(packets, &mut entries, |packet| {
+                send_packet(packet, self.send_options.clone())
+            })?;
+        } else if !packets.is_empty() {
+            // Live batches use the stateful sender contract: repeated sends must
+            // choose link_layer() or network_layer(); Auto remains a dry-run and
+            // one-shot SocketSender compatibility mode.
+            let mut sender =
+                BackendPacketSender::open_with_backend(self.send_options.clone(), backend)?;
+            self.collect_send_reports(packets, &mut entries, |packet| sender.send(packet))?;
+        }
+
+        Ok(BatchSendReport::new(
+            entries,
+            self.concurrency_limit,
+            self.retries,
+            self.retry_timeout,
+            self.send_options.is_dry_run(),
+        ))
+    }
+
+    fn collect_send_reports(
+        &self,
+        packets: &[Packet],
+        entries: &mut [BatchSendEntry],
+        mut send_one: impl FnMut(&Packet) -> Result<SendReport>,
+    ) -> Result<()> {
         for chunk_start in (0..packets.len()).step_by(self.concurrency_limit) {
             let chunk_end = (chunk_start + self.concurrency_limit).min(packets.len());
             for attempt in 0..self.retries {
                 for request_index in chunk_start..chunk_end {
-                    entries[request_index].send_reports.push(send_packet(
-                        &packets[request_index],
-                        self.send_options.clone(),
-                    )?);
+                    entries[request_index]
+                        .send_reports
+                        .push(send_one(&packets[request_index])?);
                 }
                 maybe_wait_between_live_retries(
                     self.send_options.is_dry_run(),
@@ -150,13 +202,7 @@ impl BatchSend {
             }
         }
 
-        Ok(BatchSendReport::new(
-            entries,
-            self.concurrency_limit,
-            self.retries,
-            self.retry_timeout,
-            self.send_options.is_dry_run(),
-        ))
+        Ok(())
     }
 }
 

--- a/crafter/src/net/error.rs
+++ b/crafter/src/net/error.rs
@@ -57,6 +57,13 @@ pub enum NetError {
         /// Stable diagnostic reason.
         reason: &'static str,
     },
+    /// Stateful live senders require callers to select a send class explicitly.
+    ExplicitSendModeRequired {
+        /// Requested send mode.
+        mode: SendMode,
+        /// Stable diagnostic reason.
+        reason: &'static str,
+    },
     /// The live backend cannot transmit the planned packet target.
     UnsupportedSendTarget {
         /// Planned send target.
@@ -129,6 +136,12 @@ impl fmt::Display for NetError {
                 f,
                 "cannot build {mode:?} send plan for packet '{summary}': {reason}"
             ),
+            Self::ExplicitSendModeRequired { mode, reason } => {
+                write!(
+                    f,
+                    "cannot open stateful live packet sender in {mode:?} mode: {reason}"
+                )
+            }
             Self::UnsupportedSendTarget { target, reason } => {
                 write!(f, "cannot transmit {target:?}: {reason}")
             }

--- a/crafter/src/net/mod.rs
+++ b/crafter/src/net/mod.rs
@@ -12,6 +12,7 @@
 pub mod batch;
 mod error;
 pub mod interface;
+pub(crate) mod packet_sender;
 pub mod range;
 pub mod reply;
 pub mod send;

--- a/crafter/src/net/mod.rs
+++ b/crafter/src/net/mod.rs
@@ -25,6 +25,7 @@ pub use interface::{
     find_interface_in, get_my_ip, get_my_ip_in, get_my_ipv6, get_my_ipv6_in, get_my_mac,
     get_my_mac_in, interface_for, interface_for_in, interfaces, InterfaceAddress, InterfaceInfo,
 };
+pub use packet_sender::PacketSender;
 pub use range::{get_ip_strings, get_ips, parse_ip_range, parse_numbers, Ipv4Range};
 pub use reply::{reply_filter, reply_matches, ReplyMatcher};
 pub use send::{
@@ -49,9 +50,9 @@ pub mod socket {
         reply_filter, reply_matches, send_packet, send_packets, send_plan, send_recv_packet,
         send_recv_packets, BatchSend, BatchSendEntry, BatchSendRecv, BatchSendRecvEntry,
         BatchSendRecvReport, BatchSendReport, NetError, PacketBatchSendExt, PacketBatchSendRecvExt,
-        PacketSendExt, PacketSendRecvExt, RawSender, ReplyMatcher, SendMode, SendOptions, SendPlan,
-        SendRecv, SendRecvOptions, SendRecvReport, SendReport, SendTarget, SocketSend,
-        SocketSender,
+        PacketSendExt, PacketSendRecvExt, PacketSender, RawSender, ReplyMatcher, SendMode,
+        SendOptions, SendPlan, SendRecv, SendRecvOptions, SendRecvReport, SendReport, SendTarget,
+        SocketSend, SocketSender,
     };
 }
 

--- a/crafter/src/net/packet_sender.rs
+++ b/crafter/src/net/packet_sender.rs
@@ -5,10 +5,10 @@ use pnet_datalink::{self as datalink, Channel, ChannelType, DataLinkSender};
 use pnet_packet::ip::IpNextHeaderProtocol;
 use pnet_transport::{transport_channel, TransportChannelType, TransportSender};
 
-use crate::NetworkLayer;
+use crate::{LinkType, NetworkLayer, Packet};
 
 use super::error::{NetError, Result};
-use super::send::{SendOptions, SendPlan, SendTarget};
+use super::send::{validated_interface, SendMode, SendOptions, SendPlan, SendReport, SendTarget};
 
 pub(crate) const IPPROTO_RAW_SOCKET: u8 = 255;
 
@@ -38,6 +38,101 @@ pub(crate) trait PnetBackend {
         socket_protocol: u8,
         min_packet_len: usize,
     ) -> Result<Self::NetworkSender>;
+}
+
+pub(crate) struct PacketSender<B: PnetBackend = PnetIoBackend> {
+    options: SendOptions,
+    backend: B,
+}
+
+impl PacketSender<PnetIoBackend> {
+    pub(crate) fn open(options: impl Into<SendOptions>) -> Result<Self> {
+        Self::open_with_backend(options, PnetIoBackend)
+    }
+}
+
+impl<B> PacketSender<B>
+where
+    B: PnetBackend,
+{
+    pub(crate) fn open_with_backend(options: impl Into<SendOptions>, backend: B) -> Result<Self> {
+        let options = options.into();
+        let _interface = validated_interface(&options)?;
+        if !options.is_dry_run() && options.send_mode() == SendMode::Auto {
+            return Err(NetError::ExplicitSendModeRequired {
+                mode: options.send_mode(),
+                reason: "stateful live packet senders require explicit link_layer() or network_layer() mode",
+            });
+        }
+
+        Ok(Self { options, backend })
+    }
+
+    pub(crate) const fn options(&self) -> &SendOptions {
+        &self.options
+    }
+
+    pub(crate) fn plan(&self, packet: &Packet) -> Result<SendPlan> {
+        SendPlan::from_packet(packet, self.options.clone())
+    }
+
+    pub(crate) fn send(&mut self, packet: &Packet) -> Result<SendReport> {
+        let plan = self.plan(packet)?;
+        if self.options.is_dry_run() {
+            let len = plan.len();
+            return Ok(SendReport::new(plan, len, true));
+        }
+
+        let bytes_sent = transmit_plan_with_backend(&self.backend, &plan, &self.options)?;
+        Ok(SendReport::new(plan, bytes_sent, false))
+    }
+}
+
+fn transmit_plan_with_backend<B>(
+    backend: &B,
+    plan: &SendPlan,
+    options: &SendOptions,
+) -> Result<usize>
+where
+    B: PnetBackend,
+{
+    match plan.target() {
+        SendTarget::LinkLayer { link_type } => {
+            transmit_link_target_with_backend(backend, plan, options, link_type)
+        }
+        SendTarget::NetworkLayer {
+            network_layer,
+            destination,
+            protocol,
+        } => transmit_network_with_backend(
+            backend,
+            plan,
+            options,
+            network_layer,
+            destination,
+            protocol,
+        ),
+    }
+}
+
+fn transmit_link_target_with_backend<B>(
+    backend: &B,
+    plan: &SendPlan,
+    options: &SendOptions,
+    link_type: LinkType,
+) -> Result<usize>
+where
+    B: PnetBackend,
+{
+    match link_type {
+        LinkType::Ethernet | LinkType::Radiotap => {
+            transmit_link_with_backend(backend, plan, options)
+        }
+        _ => Err(NetError::UnsupportedSendTarget {
+            target: plan.target(),
+            reason: "live link-layer send supports Ethernet and radiotap Wi-Fi frames only",
+        }),
+    }
 }
 
 pub(crate) fn transmit_link_once(plan: &SendPlan, options: &SendOptions) -> Result<usize> {
@@ -355,7 +450,7 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr};
     use std::time::Duration;
 
-    use crate::{Ethernet, Ipv4, NetworkLayer, Raw, Udp, IPPROTO_UDP};
+    use crate::{Ethernet, Ipv4, LinkType, NetworkLayer, Raw, Udp, IPPROTO_UDP};
 
     use super::*;
 
@@ -450,5 +545,62 @@ mod tests {
         assert_eq!(snapshot.network_sends[0].protocol, IPPROTO_UDP);
         assert!(snapshot.link_opens.is_empty());
         assert!(snapshot.link_sends.is_empty());
+    }
+
+    #[test]
+    fn packet_sender_requires_explicit_live_mode() {
+        let backend = FakePnetBackend::default();
+
+        let error = match PacketSender::open_with_backend(
+            SendOptions::new().iface("fake0").live(),
+            backend.clone(),
+        ) {
+            Ok(_) => panic!("stateful live sender should reject auto mode"),
+            Err(error) => error,
+        };
+
+        match error {
+            NetError::ExplicitSendModeRequired { mode, reason } => {
+                assert_eq!(mode, SendMode::Auto);
+                assert!(reason.contains("link_layer()"));
+                assert!(reason.contains("network_layer()"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+
+        let snapshot = backend.snapshot();
+        assert!(snapshot.link_opens.is_empty());
+        assert!(snapshot.network_opens.is_empty());
+        assert!(snapshot.link_sends.is_empty());
+        assert!(snapshot.network_sends.is_empty());
+    }
+
+    #[test]
+    fn packet_sender_dry_run() {
+        let backend = FakePnetBackend::default();
+        let mut sender = PacketSender::open_with_backend(
+            SendOptions::new().iface("fake0").dry_run(),
+            backend.clone(),
+        )
+        .unwrap();
+
+        let report = sender.send(&ethernet_packet()).unwrap();
+
+        assert!(report.is_dry_run());
+        assert_eq!(report.bytes_sent(), report.plan().len());
+        assert_eq!(report.plan().interface(), "fake0");
+        assert_eq!(report.plan().requested_mode(), SendMode::Auto);
+        assert_eq!(
+            report.plan().target(),
+            SendTarget::LinkLayer {
+                link_type: LinkType::Ethernet,
+            }
+        );
+
+        let snapshot = backend.snapshot();
+        assert!(snapshot.link_opens.is_empty());
+        assert!(snapshot.network_opens.is_empty());
+        assert!(snapshot.link_sends.is_empty());
+        assert!(snapshot.network_sends.is_empty());
     }
 }

--- a/crafter/src/net/packet_sender.rs
+++ b/crafter/src/net/packet_sender.rs
@@ -467,7 +467,9 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr};
     use std::time::Duration;
 
-    use crate::{Ethernet, Ipv4, LinkType, NetworkLayer, Raw, Udp, IPPROTO_UDP};
+    use crate::{
+        Dot11, Ethernet, Ipv4, LinkType, LlcSnap, NetworkLayer, Radiotap, Raw, Udp, IPPROTO_UDP,
+    };
 
     use super::*;
 
@@ -477,6 +479,17 @@ mod tests {
 
     fn ethernet_packet_with_payload(payload: &'static str) -> crate::Packet {
         Ethernet::new()
+            / Ipv4::new()
+                .src(Ipv4Addr::new(192, 0, 2, 10))
+                .dst(Ipv4Addr::new(198, 51, 100, 20))
+            / Udp::new().sport(49152).dport(53)
+            / Raw::from(payload)
+    }
+
+    fn radiotap_packet_with_payload(payload: &'static str) -> crate::Packet {
+        Radiotap::new()
+            / Dot11::data()
+            / LlcSnap::new()
             / Ipv4::new()
                 .src(Ipv4Addr::new(192, 0, 2, 10))
                 .dst(Ipv4Addr::new(198, 51, 100, 20))
@@ -682,6 +695,63 @@ mod tests {
             snapshot.link_opens[0].target,
             SendTarget::LinkLayer {
                 link_type: LinkType::Ethernet,
+            }
+        );
+        assert_eq!(snapshot.link_sends.len(), 2);
+        assert_eq!(snapshot.link_sends[0].target, first_plan.target());
+        assert_eq!(snapshot.link_sends[0].bytes, first_plan.bytes());
+        assert_eq!(snapshot.link_sends[1].target, second_plan.target());
+        assert_eq!(snapshot.link_sends[1].bytes, second_plan.bytes());
+        assert!(snapshot.network_opens.is_empty());
+        assert!(snapshot.network_sends.is_empty());
+    }
+
+    #[test]
+    fn live_link_layer_sender_writes_radiotap_frames() {
+        let backend = FakePnetBackend::default();
+        let mut sender = PacketSender::open_with_backend(
+            SendOptions::new().iface("fake0").link_layer().live(),
+            backend.clone(),
+        )
+        .unwrap();
+
+        let first = radiotap_packet_with_payload("one");
+        let second = radiotap_packet_with_payload("two");
+        let first_plan = SendPlan::from_packet(
+            &first,
+            SendOptions::new().iface("fake0").link_layer().dry_run(),
+        )
+        .unwrap();
+        let second_plan = SendPlan::from_packet(
+            &second,
+            SendOptions::new().iface("fake0").link_layer().dry_run(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            first_plan.target(),
+            SendTarget::LinkLayer {
+                link_type: LinkType::Radiotap,
+            }
+        );
+        assert_eq!(
+            second_plan.target(),
+            SendTarget::LinkLayer {
+                link_type: LinkType::Radiotap,
+            }
+        );
+        assert_eq!(first_plan.bytes()[..8], [0, 0, 8, 0, 0, 0, 0, 0]);
+        assert_eq!(second_plan.bytes()[..8], [0, 0, 8, 0, 0, 0, 0, 0]);
+
+        sender.send(&first).unwrap();
+        sender.send(&second).unwrap();
+
+        let snapshot = backend.snapshot();
+        assert_eq!(snapshot.link_opens.len(), 1);
+        assert_eq!(
+            snapshot.link_opens[0].target,
+            SendTarget::LinkLayer {
+                link_type: LinkType::Radiotap,
             }
         );
         assert_eq!(snapshot.link_sends.len(), 2);

--- a/crafter/src/net/packet_sender.rs
+++ b/crafter/src/net/packet_sender.rs
@@ -1,0 +1,454 @@
+use std::io;
+use std::net::IpAddr;
+
+use pnet_datalink::{self as datalink, Channel, ChannelType, DataLinkSender};
+use pnet_packet::ip::IpNextHeaderProtocol;
+use pnet_transport::{transport_channel, TransportChannelType, TransportSender};
+
+use crate::NetworkLayer;
+
+use super::error::{NetError, Result};
+use super::send::{SendOptions, SendPlan, SendTarget};
+
+pub(crate) const IPPROTO_RAW_SOCKET: u8 = 255;
+
+pub(crate) trait LinkSenderBackend {
+    fn send_link(&mut self, target: SendTarget, bytes: &[u8]) -> Result<usize>;
+}
+
+pub(crate) trait NetworkSenderBackend {
+    fn send_ipv4(
+        &mut self,
+        target: SendTarget,
+        bytes: &[u8],
+        destination: IpAddr,
+        protocol: u8,
+    ) -> Result<usize>;
+}
+
+pub(crate) trait PnetBackend {
+    type LinkSender: LinkSenderBackend;
+    type NetworkSender: NetworkSenderBackend;
+
+    fn open_link_sender(&self, plan: &SendPlan, options: &SendOptions) -> Result<Self::LinkSender>;
+
+    fn open_network_sender(
+        &self,
+        options: &SendOptions,
+        socket_protocol: u8,
+        min_packet_len: usize,
+    ) -> Result<Self::NetworkSender>;
+}
+
+pub(crate) fn transmit_link_once(plan: &SendPlan, options: &SendOptions) -> Result<usize> {
+    transmit_link_with_backend(&PnetIoBackend, plan, options)
+}
+
+pub(crate) fn transmit_link_with_backend<B>(
+    backend: &B,
+    plan: &SendPlan,
+    options: &SendOptions,
+) -> Result<usize>
+where
+    B: PnetBackend,
+{
+    let mut sender = backend.open_link_sender(plan, options)?;
+    sender.send_link(plan.target(), plan.bytes())
+}
+
+pub(crate) fn transmit_network_once(
+    plan: &SendPlan,
+    options: &SendOptions,
+    network_layer: NetworkLayer,
+    destination: IpAddr,
+    protocol: u8,
+) -> Result<usize> {
+    transmit_network_with_backend(
+        &PnetIoBackend,
+        plan,
+        options,
+        network_layer,
+        destination,
+        protocol,
+    )
+}
+
+pub(crate) fn transmit_network_with_backend<B>(
+    backend: &B,
+    plan: &SendPlan,
+    options: &SendOptions,
+    network_layer: NetworkLayer,
+    destination: IpAddr,
+    protocol: u8,
+) -> Result<usize>
+where
+    B: PnetBackend,
+{
+    let socket_protocol = match network_layer {
+        NetworkLayer::Ipv4 => IPPROTO_RAW_SOCKET,
+        NetworkLayer::Ipv6 | NetworkLayer::Raw => protocol,
+    };
+    let mut sender = backend.open_network_sender(options, socket_protocol, plan.len())?;
+
+    match network_layer {
+        NetworkLayer::Ipv4 => sender.send_ipv4(plan.target(), plan.bytes(), destination, protocol),
+        NetworkLayer::Ipv6 => Err(NetError::UnsupportedSendTarget {
+            target: plan.target(),
+            reason: "the selected safe backend does not support full IPv6-header Layer3 sends",
+        }),
+        NetworkLayer::Raw => Err(NetError::UnsupportedSendTarget {
+            target: plan.target(),
+            reason: "raw network-layer sends require an IPv4 or IPv6 header",
+        }),
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct PnetIoBackend;
+
+pub(crate) struct PnetLinkSender {
+    interface: String,
+    tx: Box<dyn DataLinkSender>,
+}
+
+pub(crate) struct PnetNetworkSender {
+    tx: TransportSender,
+}
+
+impl PnetBackend for PnetIoBackend {
+    type LinkSender = PnetLinkSender;
+    type NetworkSender = PnetNetworkSender;
+
+    fn open_link_sender(&self, plan: &SendPlan, options: &SendOptions) -> Result<Self::LinkSender> {
+        let interface = datalink::interfaces()
+            .into_iter()
+            .find(|candidate| candidate.name == plan.interface())
+            .ok_or_else(|| NetError::InterfaceNotFound {
+                name: plan.interface().to_string(),
+            })?;
+
+        let config = datalink::Config {
+            channel_type: ChannelType::Layer2,
+            write_timeout: options.write_timeout_hint(),
+            write_buffer_size: options.write_buffer_size_hint().max(plan.len()),
+            ..Default::default()
+        };
+
+        let channel = datalink::channel(&interface, config)
+            .map_err(|source| net_io_error("open datalink channel", source))?;
+
+        match channel {
+            Channel::Ethernet(tx, _) => Ok(PnetLinkSender {
+                interface: plan.interface().to_string(),
+                tx,
+            }),
+            _ => Err(NetError::UnsupportedDatalinkChannel {
+                interface: plan.interface().to_string(),
+            }),
+        }
+    }
+
+    fn open_network_sender(
+        &self,
+        options: &SendOptions,
+        socket_protocol: u8,
+        min_packet_len: usize,
+    ) -> Result<Self::NetworkSender> {
+        let channel_type = TransportChannelType::Layer3(IpNextHeaderProtocol::new(socket_protocol));
+        let buffer_size = options.write_buffer_size_hint().max(min_packet_len);
+        let (tx, _) = transport_channel(buffer_size, channel_type)
+            .map_err(|source| net_io_error("open raw network socket", source))?;
+        Ok(PnetNetworkSender { tx })
+    }
+}
+
+impl LinkSenderBackend for PnetLinkSender {
+    fn send_link(&mut self, _target: SendTarget, bytes: &[u8]) -> Result<usize> {
+        let result =
+            self.tx
+                .send_to(bytes, None)
+                .ok_or_else(|| NetError::SendBufferUnavailable {
+                    interface: self.interface.clone(),
+                    len: bytes.len(),
+                })?;
+        result.map_err(|source| net_io_error("send datalink frame", source))?;
+        Ok(bytes.len())
+    }
+}
+
+impl NetworkSenderBackend for PnetNetworkSender {
+    fn send_ipv4(
+        &mut self,
+        target: SendTarget,
+        bytes: &[u8],
+        destination: IpAddr,
+        _protocol: u8,
+    ) -> Result<usize> {
+        let packet = pnet_packet::ipv4::Ipv4Packet::new(bytes).ok_or({
+            NetError::UnsupportedSendTarget {
+                target,
+                reason: "compiled bytes are not a complete IPv4 packet",
+            }
+        })?;
+        self.tx
+            .send_to(packet, destination)
+            .map_err(|source| net_io_error("send IPv4 packet", source))
+    }
+}
+
+fn net_io_error(operation: &'static str, source: io::Error) -> NetError {
+    if source.kind() == io::ErrorKind::PermissionDenied {
+        NetError::PermissionDenied { operation, source }
+    } else {
+        NetError::Io { operation, source }
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Default)]
+pub(crate) struct FakePnetBackend {
+    state: std::sync::Arc<std::sync::Mutex<FakePnetBackendState>>,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct FakePnetBackendState {
+    pub(crate) link_opens: Vec<FakeLinkOpen>,
+    pub(crate) network_opens: Vec<FakeNetworkOpen>,
+    pub(crate) link_sends: Vec<FakeLinkSend>,
+    pub(crate) network_sends: Vec<FakeNetworkSend>,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FakeLinkOpen {
+    pub(crate) interface: String,
+    pub(crate) target: SendTarget,
+    pub(crate) write_timeout: Option<std::time::Duration>,
+    pub(crate) write_buffer_size: usize,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FakeNetworkOpen {
+    pub(crate) socket_protocol: u8,
+    pub(crate) write_buffer_size: usize,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FakeLinkSend {
+    pub(crate) target: SendTarget,
+    pub(crate) bytes: Vec<u8>,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FakeNetworkSend {
+    pub(crate) target: SendTarget,
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) destination: IpAddr,
+    pub(crate) protocol: u8,
+}
+
+#[cfg(test)]
+impl FakePnetBackend {
+    pub(crate) fn snapshot(&self) -> FakePnetBackendState {
+        self.state
+            .lock()
+            .expect("fake pnet backend mutex poisoned")
+            .clone()
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct FakeLinkSender {
+    state: std::sync::Arc<std::sync::Mutex<FakePnetBackendState>>,
+}
+
+#[cfg(test)]
+pub(crate) struct FakeNetworkSender {
+    state: std::sync::Arc<std::sync::Mutex<FakePnetBackendState>>,
+}
+
+#[cfg(test)]
+impl PnetBackend for FakePnetBackend {
+    type LinkSender = FakeLinkSender;
+    type NetworkSender = FakeNetworkSender;
+
+    fn open_link_sender(&self, plan: &SendPlan, options: &SendOptions) -> Result<Self::LinkSender> {
+        self.state
+            .lock()
+            .expect("fake pnet backend mutex poisoned")
+            .link_opens
+            .push(FakeLinkOpen {
+                interface: plan.interface().to_string(),
+                target: plan.target(),
+                write_timeout: options.write_timeout_hint(),
+                write_buffer_size: options.write_buffer_size_hint().max(plan.len()),
+            });
+        Ok(FakeLinkSender {
+            state: self.state.clone(),
+        })
+    }
+
+    fn open_network_sender(
+        &self,
+        options: &SendOptions,
+        socket_protocol: u8,
+        min_packet_len: usize,
+    ) -> Result<Self::NetworkSender> {
+        self.state
+            .lock()
+            .expect("fake pnet backend mutex poisoned")
+            .network_opens
+            .push(FakeNetworkOpen {
+                socket_protocol,
+                write_buffer_size: options.write_buffer_size_hint().max(min_packet_len),
+            });
+        Ok(FakeNetworkSender {
+            state: self.state.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+impl LinkSenderBackend for FakeLinkSender {
+    fn send_link(&mut self, target: SendTarget, bytes: &[u8]) -> Result<usize> {
+        self.state
+            .lock()
+            .expect("fake pnet backend mutex poisoned")
+            .link_sends
+            .push(FakeLinkSend {
+                target,
+                bytes: bytes.to_vec(),
+            });
+        Ok(bytes.len())
+    }
+}
+
+#[cfg(test)]
+impl NetworkSenderBackend for FakeNetworkSender {
+    fn send_ipv4(
+        &mut self,
+        target: SendTarget,
+        bytes: &[u8],
+        destination: IpAddr,
+        protocol: u8,
+    ) -> Result<usize> {
+        self.state
+            .lock()
+            .expect("fake pnet backend mutex poisoned")
+            .network_sends
+            .push(FakeNetworkSend {
+                target,
+                bytes: bytes.to_vec(),
+                destination,
+                protocol,
+            });
+        Ok(bytes.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::time::Duration;
+
+    use crate::{Ethernet, Ipv4, NetworkLayer, Raw, Udp, IPPROTO_UDP};
+
+    use super::*;
+
+    fn ethernet_packet() -> crate::Packet {
+        Ethernet::new()
+            / Ipv4::new()
+                .src(Ipv4Addr::new(192, 0, 2, 10))
+                .dst(Ipv4Addr::new(198, 51, 100, 20))
+            / Udp::new().sport(49152).dport(53)
+            / Raw::from("payload")
+    }
+
+    fn ipv4_packet() -> crate::Packet {
+        Ipv4::new()
+            .src(Ipv4Addr::new(192, 0, 2, 10))
+            .dst(Ipv4Addr::new(198, 51, 100, 20))
+            / Udp::new().sport(49152).dport(53)
+            / Raw::from("payload")
+    }
+
+    #[test]
+    fn packet_sender_backend_fake_records_link_accounting() {
+        let backend = FakePnetBackend::default();
+        let options = SendOptions::new()
+            .iface("fake0")
+            .link_layer()
+            .write_timeout(Duration::from_millis(25))
+            .write_buffer_size(8);
+        let plan = SendPlan::from_packet(&ethernet_packet(), options.clone()).unwrap();
+
+        let bytes_sent = transmit_link_with_backend(&backend, &plan, &options).unwrap();
+
+        assert_eq!(bytes_sent, plan.len());
+        let snapshot = backend.snapshot();
+        assert_eq!(snapshot.link_opens.len(), 1);
+        assert_eq!(snapshot.link_opens[0].interface, "fake0");
+        assert_eq!(snapshot.link_opens[0].target, plan.target());
+        assert_eq!(
+            snapshot.link_opens[0].write_timeout,
+            Some(Duration::from_millis(25))
+        );
+        assert_eq!(snapshot.link_opens[0].write_buffer_size, plan.len());
+        assert_eq!(snapshot.link_sends.len(), 1);
+        assert_eq!(snapshot.link_sends[0].target, plan.target());
+        assert_eq!(snapshot.link_sends[0].bytes, plan.bytes());
+        assert!(snapshot.network_opens.is_empty());
+        assert!(snapshot.network_sends.is_empty());
+    }
+
+    #[test]
+    fn packet_sender_backend_fake_records_ipv4_network_accounting() {
+        let backend = FakePnetBackend::default();
+        let options = SendOptions::new()
+            .iface("fake0")
+            .network_layer()
+            .write_buffer_size(4);
+        let plan = SendPlan::from_packet(&ipv4_packet(), options.clone()).unwrap();
+        let SendTarget::NetworkLayer {
+            network_layer,
+            destination,
+            protocol,
+        } = plan.target()
+        else {
+            panic!("expected IPv4 network target");
+        };
+
+        let bytes_sent = transmit_network_with_backend(
+            &backend,
+            &plan,
+            &options,
+            network_layer,
+            destination,
+            protocol,
+        )
+        .unwrap();
+
+        assert_eq!(network_layer, NetworkLayer::Ipv4);
+        assert_eq!(destination, IpAddr::V4(Ipv4Addr::new(198, 51, 100, 20)));
+        assert_eq!(protocol, IPPROTO_UDP);
+        assert_eq!(bytes_sent, plan.len());
+        let snapshot = backend.snapshot();
+        assert_eq!(snapshot.network_opens.len(), 1);
+        assert_eq!(
+            snapshot.network_opens[0].socket_protocol,
+            IPPROTO_RAW_SOCKET
+        );
+        assert_eq!(snapshot.network_opens[0].write_buffer_size, plan.len());
+        assert_eq!(snapshot.network_sends.len(), 1);
+        assert_eq!(snapshot.network_sends[0].target, plan.target());
+        assert_eq!(snapshot.network_sends[0].bytes, plan.bytes());
+        assert_eq!(snapshot.network_sends[0].destination, destination);
+        assert_eq!(snapshot.network_sends[0].protocol, IPPROTO_UDP);
+        assert!(snapshot.link_opens.is_empty());
+        assert!(snapshot.link_sends.is_empty());
+    }
+}

--- a/crafter/src/net/packet_sender.rs
+++ b/crafter/src/net/packet_sender.rs
@@ -95,6 +95,8 @@ where
     }
 
     fn transmit_plan(&mut self, plan: &SendPlan) -> Result<usize> {
+        self.validate_target_class(plan)?;
+
         match plan.target() {
             SendTarget::LinkLayer { link_type } => self.transmit_link_target(plan, link_type),
             SendTarget::NetworkLayer {
@@ -102,6 +104,24 @@ where
                 destination,
                 protocol,
             } => self.transmit_network_target(plan, network_layer, destination, protocol),
+        }
+    }
+
+    fn validate_target_class(&self, plan: &SendPlan) -> Result<()> {
+        match (self.options.send_mode(), plan.target()) {
+            (SendMode::LinkLayer, target) if target.is_network_layer() => {
+                Err(NetError::UnsupportedSendTarget {
+                    target,
+                    reason: "stateful link-layer sender cannot transmit network-layer packets; open a network_layer() sender for this packet",
+                })
+            }
+            (SendMode::NetworkLayer, target) if target.is_link_layer() => {
+                Err(NetError::UnsupportedSendTarget {
+                    target,
+                    reason: "stateful network-layer sender cannot transmit link-layer frames; open a link_layer() sender for this packet",
+                })
+            }
+            _ => Ok(()),
         }
     }
 
@@ -231,14 +251,12 @@ pub(crate) fn transmit_network_with_backend<B>(
 where
     B: PnetBackend,
 {
-    let socket_protocol = match network_layer {
-        NetworkLayer::Ipv4 => IPPROTO_RAW_SOCKET,
-        NetworkLayer::Ipv6 | NetworkLayer::Raw => protocol,
-    };
-    let mut sender = backend.open_network_sender(options, socket_protocol, plan.len())?;
-
     match network_layer {
-        NetworkLayer::Ipv4 => sender.send_ipv4(plan.target(), plan.bytes(), destination, protocol),
+        NetworkLayer::Ipv4 => {
+            let mut sender =
+                backend.open_network_sender(options, IPPROTO_RAW_SOCKET, plan.len())?;
+            sender.send_ipv4(plan.target(), plan.bytes(), destination, protocol)
+        }
         NetworkLayer::Ipv6 => Err(NetError::UnsupportedSendTarget {
             target: plan.target(),
             reason: "the selected safe backend does not support full IPv6-header Layer3 sends",
@@ -499,11 +517,12 @@ impl NetworkSenderBackend for FakeNetworkSender {
 
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use std::time::Duration;
 
     use crate::{
-        Dot11, Ethernet, Ipv4, LinkType, LlcSnap, NetworkLayer, Radiotap, Raw, Udp, IPPROTO_UDP,
+        Dot11, Ethernet, Ipv4, Ipv6, LinkType, LinuxSll, LlcSnap, NetworkLayer, NullLoopback,
+        Radiotap, Raw, Udp, IPPROTO_UDP,
     };
 
     use super::*;
@@ -542,6 +561,22 @@ mod tests {
             .dst(destination)
             / Udp::new().sport(49152).dport(53)
             / Raw::from(payload)
+    }
+
+    fn ipv6_packet() -> crate::Packet {
+        Ipv6::new()
+            .src(Ipv6Addr::new(2001, 0xdb8, 0, 0, 0, 0, 0, 10))
+            .dst(Ipv6Addr::new(2001, 0xdb8, 0, 0, 0, 0, 0, 20))
+            / Udp::new().sport(49152).dport(53)
+            / Raw::from("payload")
+    }
+
+    fn linux_sll_packet() -> crate::Packet {
+        LinuxSll::new() / ipv4_packet()
+    }
+
+    fn null_loopback_packet() -> crate::Packet {
+        NullLoopback::ipv4() / ipv4_packet()
     }
 
     #[test]
@@ -878,5 +913,166 @@ mod tests {
         assert_eq!(snapshot.network_sends[1].protocol, IPPROTO_UDP);
         assert!(snapshot.link_opens.is_empty());
         assert!(snapshot.link_sends.is_empty());
+    }
+
+    #[test]
+    fn packet_sender_rejects_mixed_send_classes() {
+        let link_backend = FakePnetBackend::default();
+        let mut link_sender = PacketSender::open_with_backend(
+            SendOptions::new().iface("fake0").link_layer().live(),
+            link_backend.clone(),
+        )
+        .unwrap();
+
+        link_sender.send(&ethernet_packet()).unwrap();
+        let ipv4_error = link_sender.send(&ipv4_packet()).unwrap_err();
+        let ipv6_error = link_sender.send(&ipv6_packet()).unwrap_err();
+        let ipv4_plan = SendPlan::from_packet(
+            &ipv4_packet(),
+            SendOptions::new().iface("fake0").network_layer().dry_run(),
+        )
+        .unwrap();
+        let boundary_error = link_sender.transmit_plan(&ipv4_plan).unwrap_err();
+
+        assert_unsupported_shape(ipv4_error, SendMode::LinkLayer);
+        assert_unsupported_shape(ipv6_error, SendMode::LinkLayer);
+        assert_mode_boundary_error(
+            boundary_error,
+            ipv4_plan.target(),
+            "stateful link-layer sender cannot transmit network-layer packets",
+        );
+        let snapshot = link_backend.snapshot();
+        assert_eq!(snapshot.link_opens.len(), 1);
+        assert_eq!(snapshot.link_sends.len(), 1);
+        assert!(snapshot.network_opens.is_empty());
+        assert!(snapshot.network_sends.is_empty());
+
+        let network_backend = FakePnetBackend::default();
+        let mut network_sender = PacketSender::open_with_backend(
+            SendOptions::new().iface("fake0").network_layer().live(),
+            network_backend.clone(),
+        )
+        .unwrap();
+
+        network_sender.send(&ipv4_packet()).unwrap();
+        let ethernet_error = network_sender.send(&ethernet_packet()).unwrap_err();
+        let radiotap_error = network_sender
+            .send(&radiotap_packet_with_payload("wifi"))
+            .unwrap_err();
+        let ethernet_plan = SendPlan::from_packet(
+            &ethernet_packet(),
+            SendOptions::new().iface("fake0").link_layer().dry_run(),
+        )
+        .unwrap();
+        let boundary_error = network_sender.transmit_plan(&ethernet_plan).unwrap_err();
+
+        assert_unsupported_shape(ethernet_error, SendMode::NetworkLayer);
+        assert_unsupported_shape(radiotap_error, SendMode::NetworkLayer);
+        assert_mode_boundary_error(
+            boundary_error,
+            ethernet_plan.target(),
+            "stateful network-layer sender cannot transmit link-layer frames",
+        );
+        let snapshot = network_backend.snapshot();
+        assert!(snapshot.link_opens.is_empty());
+        assert!(snapshot.link_sends.is_empty());
+        assert_eq!(snapshot.network_opens.len(), 1);
+        assert_eq!(snapshot.network_sends.len(), 1);
+    }
+
+    #[test]
+    fn packet_sender_rejects_unsupported_live_targets() {
+        let link_backend = FakePnetBackend::default();
+        let mut link_sender = PacketSender::open_with_backend(
+            SendOptions::new().iface("fake0").link_layer().live(),
+            link_backend.clone(),
+        )
+        .unwrap();
+
+        let linux_sll_error = link_sender.send(&linux_sll_packet()).unwrap_err();
+        let null_loopback_error = link_sender.send(&null_loopback_packet()).unwrap_err();
+
+        assert_unsupported_target(
+            linux_sll_error,
+            SendTarget::LinkLayer {
+                link_type: LinkType::LinuxSll,
+            },
+            "live link-layer send supports Ethernet and radiotap Wi-Fi frames only",
+        );
+        assert_unsupported_target(
+            null_loopback_error,
+            SendTarget::LinkLayer {
+                link_type: LinkType::NullLoopback,
+            },
+            "live link-layer send supports Ethernet and radiotap Wi-Fi frames only",
+        );
+        let snapshot = link_backend.snapshot();
+        assert!(snapshot.link_opens.is_empty());
+        assert!(snapshot.link_sends.is_empty());
+        assert!(snapshot.network_opens.is_empty());
+        assert!(snapshot.network_sends.is_empty());
+
+        let network_backend = FakePnetBackend::default();
+        let mut network_sender = PacketSender::open_with_backend(
+            SendOptions::new().iface("fake0").network_layer().live(),
+            network_backend.clone(),
+        )
+        .unwrap();
+
+        let ipv6_error = network_sender.send(&ipv6_packet()).unwrap_err();
+
+        assert_unsupported_target(
+            ipv6_error,
+            SendPlan::from_packet(
+                &ipv6_packet(),
+                SendOptions::new().iface("fake0").network_layer().dry_run(),
+            )
+            .unwrap()
+            .target(),
+            "the selected safe backend does not support full IPv6-header Layer3 sends",
+        );
+        let snapshot = network_backend.snapshot();
+        assert!(snapshot.link_opens.is_empty());
+        assert!(snapshot.link_sends.is_empty());
+        assert!(snapshot.network_opens.is_empty());
+        assert!(snapshot.network_sends.is_empty());
+    }
+
+    fn assert_unsupported_shape(error: NetError, mode: SendMode) {
+        match error {
+            NetError::UnsupportedPacketShape {
+                mode: actual_mode, ..
+            } => {
+                assert_eq!(actual_mode, mode);
+            }
+            other => panic!("expected unsupported packet shape, got {other}"),
+        }
+    }
+
+    fn assert_mode_boundary_error(error: NetError, target: SendTarget, expected_reason: &str) {
+        match error {
+            NetError::UnsupportedSendTarget {
+                target: actual,
+                reason,
+            } => {
+                assert_eq!(actual, target);
+                assert!(reason.contains(expected_reason));
+            }
+            other => panic!("expected unsupported send target, got {other}"),
+        }
+    }
+
+    fn assert_unsupported_target(
+        error: NetError,
+        expected_target: SendTarget,
+        expected_reason: &str,
+    ) {
+        match error {
+            NetError::UnsupportedSendTarget { target, reason } => {
+                assert_eq!(target, expected_target);
+                assert_eq!(reason, expected_reason);
+            }
+            other => panic!("expected unsupported send target, got {other}"),
+        }
     }
 }

--- a/crafter/src/net/packet_sender.rs
+++ b/crafter/src/net/packet_sender.rs
@@ -43,6 +43,7 @@ pub(crate) trait PnetBackend {
 pub(crate) struct PacketSender<B: PnetBackend = PnetIoBackend> {
     options: SendOptions,
     backend: B,
+    link_sender: Option<B::LinkSender>,
 }
 
 impl PacketSender<PnetIoBackend> {
@@ -65,7 +66,11 @@ where
             });
         }
 
-        Ok(Self { options, backend })
+        Ok(Self {
+            options,
+            backend,
+            link_sender: None,
+        })
     }
 
     pub(crate) const fn options(&self) -> &SendOptions {
@@ -83,35 +88,47 @@ where
             return Ok(SendReport::new(plan, len, true));
         }
 
-        let bytes_sent = transmit_plan_with_backend(&self.backend, &plan, &self.options)?;
+        let bytes_sent = self.transmit_plan(&plan)?;
         Ok(SendReport::new(plan, bytes_sent, false))
     }
-}
 
-fn transmit_plan_with_backend<B>(
-    backend: &B,
-    plan: &SendPlan,
-    options: &SendOptions,
-) -> Result<usize>
-where
-    B: PnetBackend,
-{
-    match plan.target() {
-        SendTarget::LinkLayer { link_type } => {
-            transmit_link_target_with_backend(backend, plan, options, link_type)
+    fn transmit_plan(&mut self, plan: &SendPlan) -> Result<usize> {
+        match plan.target() {
+            SendTarget::LinkLayer { link_type } => self.transmit_link_target(plan, link_type),
+            SendTarget::NetworkLayer {
+                network_layer,
+                destination,
+                protocol,
+            } => transmit_network_with_backend(
+                &self.backend,
+                plan,
+                &self.options,
+                network_layer,
+                destination,
+                protocol,
+            ),
         }
-        SendTarget::NetworkLayer {
-            network_layer,
-            destination,
-            protocol,
-        } => transmit_network_with_backend(
-            backend,
-            plan,
-            options,
-            network_layer,
-            destination,
-            protocol,
-        ),
+    }
+
+    fn transmit_link_target(&mut self, plan: &SendPlan, link_type: LinkType) -> Result<usize> {
+        match link_type {
+            LinkType::Ethernet | LinkType::Radiotap => self.transmit_link(plan),
+            _ => Err(NetError::UnsupportedSendTarget {
+                target: plan.target(),
+                reason: "live link-layer send supports Ethernet and radiotap Wi-Fi frames only",
+            }),
+        }
+    }
+
+    fn transmit_link(&mut self, plan: &SendPlan) -> Result<usize> {
+        if self.link_sender.is_none() {
+            self.link_sender = Some(self.backend.open_link_sender(plan, &self.options)?);
+        }
+
+        self.link_sender
+            .as_mut()
+            .expect("link sender is initialized before send")
+            .send_link(plan.target(), plan.bytes())
     }
 }
 
@@ -455,12 +472,16 @@ mod tests {
     use super::*;
 
     fn ethernet_packet() -> crate::Packet {
+        ethernet_packet_with_payload("payload")
+    }
+
+    fn ethernet_packet_with_payload(payload: &'static str) -> crate::Packet {
         Ethernet::new()
             / Ipv4::new()
                 .src(Ipv4Addr::new(192, 0, 2, 10))
                 .dst(Ipv4Addr::new(198, 51, 100, 20))
             / Udp::new().sport(49152).dport(53)
-            / Raw::from("payload")
+            / Raw::from(payload)
     }
 
     fn ipv4_packet() -> crate::Packet {
@@ -601,6 +622,74 @@ mod tests {
         assert!(snapshot.link_opens.is_empty());
         assert!(snapshot.network_opens.is_empty());
         assert!(snapshot.link_sends.is_empty());
+        assert!(snapshot.network_sends.is_empty());
+    }
+
+    #[test]
+    fn live_link_layer_sender_opens_once() {
+        let backend = FakePnetBackend::default();
+        let mut sender = PacketSender::open_with_backend(
+            SendOptions::new().iface("fake0").link_layer().live(),
+            backend.clone(),
+        )
+        .unwrap();
+
+        let first = ethernet_packet_with_payload("first");
+        let second = ethernet_packet_with_payload("second");
+        let first_report = sender.send(&first).unwrap();
+        let second_report = sender.send(&second).unwrap();
+
+        assert!(!first_report.is_dry_run());
+        assert!(!second_report.is_dry_run());
+        assert_eq!(first_report.bytes_sent(), first_report.plan().len());
+        assert_eq!(second_report.bytes_sent(), second_report.plan().len());
+
+        let snapshot = backend.snapshot();
+        assert_eq!(snapshot.link_opens.len(), 1);
+        assert_eq!(snapshot.link_sends.len(), 2);
+        assert!(snapshot.network_opens.is_empty());
+        assert!(snapshot.network_sends.is_empty());
+    }
+
+    #[test]
+    fn live_link_layer_sender_writes_ethernet_frames() {
+        let backend = FakePnetBackend::default();
+        let mut sender = PacketSender::open_with_backend(
+            SendOptions::new().iface("fake0").link_layer().live(),
+            backend.clone(),
+        )
+        .unwrap();
+
+        let first = ethernet_packet_with_payload("one");
+        let second = ethernet_packet_with_payload("two");
+        let first_plan = SendPlan::from_packet(
+            &first,
+            SendOptions::new().iface("fake0").link_layer().dry_run(),
+        )
+        .unwrap();
+        let second_plan = SendPlan::from_packet(
+            &second,
+            SendOptions::new().iface("fake0").link_layer().dry_run(),
+        )
+        .unwrap();
+
+        sender.send(&first).unwrap();
+        sender.send(&second).unwrap();
+
+        let snapshot = backend.snapshot();
+        assert_eq!(snapshot.link_opens.len(), 1);
+        assert_eq!(
+            snapshot.link_opens[0].target,
+            SendTarget::LinkLayer {
+                link_type: LinkType::Ethernet,
+            }
+        );
+        assert_eq!(snapshot.link_sends.len(), 2);
+        assert_eq!(snapshot.link_sends[0].target, first_plan.target());
+        assert_eq!(snapshot.link_sends[0].bytes, first_plan.bytes());
+        assert_eq!(snapshot.link_sends[1].target, second_plan.target());
+        assert_eq!(snapshot.link_sends[1].bytes, second_plan.bytes());
+        assert!(snapshot.network_opens.is_empty());
         assert!(snapshot.network_sends.is_empty());
     }
 }

--- a/crafter/src/net/packet_sender.rs
+++ b/crafter/src/net/packet_sender.rs
@@ -60,8 +60,7 @@ impl PacketSender {
     /// [`SendOptions::network_layer`] for supported network-layer packets.
     /// Dry-run senders never open an OS raw socket.
     pub fn open(options: impl Into<SendOptions>) -> Result<Self> {
-        BackendPacketSender::open_with_backend(options, PnetIoBackend)
-            .map(|inner| Self { inner })
+        BackendPacketSender::open_with_backend(options, PnetIoBackend).map(|inner| Self { inner })
     }
 
     /// Borrow this sender's options.
@@ -221,30 +220,7 @@ where
     }
 }
 
-fn transmit_link_target_with_backend<B>(
-    backend: &B,
-    plan: &SendPlan,
-    options: &SendOptions,
-    link_type: LinkType,
-) -> Result<usize>
-where
-    B: PnetBackend,
-{
-    match link_type {
-        LinkType::Ethernet | LinkType::Radiotap => {
-            transmit_link_with_backend(backend, plan, options)
-        }
-        _ => Err(NetError::UnsupportedSendTarget {
-            target: plan.target(),
-            reason: "live link-layer send supports Ethernet and radiotap Wi-Fi frames only",
-        }),
-    }
-}
-
-pub(crate) fn transmit_link_once(plan: &SendPlan, options: &SendOptions) -> Result<usize> {
-    transmit_link_with_backend(&PnetIoBackend, plan, options)
-}
-
+#[cfg(test)]
 pub(crate) fn transmit_link_with_backend<B>(
     backend: &B,
     plan: &SendPlan,
@@ -257,23 +233,7 @@ where
     sender.send_link(plan.target(), plan.bytes())
 }
 
-pub(crate) fn transmit_network_once(
-    plan: &SendPlan,
-    options: &SendOptions,
-    network_layer: NetworkLayer,
-    destination: IpAddr,
-    protocol: u8,
-) -> Result<usize> {
-    transmit_network_with_backend(
-        &PnetIoBackend,
-        plan,
-        options,
-        network_layer,
-        destination,
-        protocol,
-    )
-}
-
+#[cfg(test)]
 pub(crate) fn transmit_network_with_backend<B>(
     backend: &B,
     plan: &SendPlan,

--- a/crafter/src/net/packet_sender.rs
+++ b/crafter/src/net/packet_sender.rs
@@ -44,6 +44,7 @@ pub(crate) struct PacketSender<B: PnetBackend = PnetIoBackend> {
     options: SendOptions,
     backend: B,
     link_sender: Option<B::LinkSender>,
+    network_sender: Option<B::NetworkSender>,
 }
 
 impl PacketSender<PnetIoBackend> {
@@ -70,6 +71,7 @@ where
             options,
             backend,
             link_sender: None,
+            network_sender: None,
         })
     }
 
@@ -99,14 +101,7 @@ where
                 network_layer,
                 destination,
                 protocol,
-            } => transmit_network_with_backend(
-                &self.backend,
-                plan,
-                &self.options,
-                network_layer,
-                destination,
-                protocol,
-            ),
+            } => self.transmit_network_target(plan, network_layer, destination, protocol),
         }
     }
 
@@ -129,6 +124,46 @@ where
             .as_mut()
             .expect("link sender is initialized before send")
             .send_link(plan.target(), plan.bytes())
+    }
+
+    fn transmit_network_target(
+        &mut self,
+        plan: &SendPlan,
+        network_layer: NetworkLayer,
+        destination: IpAddr,
+        protocol: u8,
+    ) -> Result<usize> {
+        match network_layer {
+            NetworkLayer::Ipv4 => self.transmit_ipv4(plan, destination, protocol),
+            NetworkLayer::Ipv6 => Err(NetError::UnsupportedSendTarget {
+                target: plan.target(),
+                reason: "the selected safe backend does not support full IPv6-header Layer3 sends",
+            }),
+            NetworkLayer::Raw => Err(NetError::UnsupportedSendTarget {
+                target: plan.target(),
+                reason: "raw network-layer sends require an IPv4 or IPv6 header",
+            }),
+        }
+    }
+
+    fn transmit_ipv4(
+        &mut self,
+        plan: &SendPlan,
+        destination: IpAddr,
+        protocol: u8,
+    ) -> Result<usize> {
+        if self.network_sender.is_none() {
+            self.network_sender = Some(self.backend.open_network_sender(
+                &self.options,
+                IPPROTO_RAW_SOCKET,
+                plan.len(),
+            )?);
+        }
+
+        self.network_sender
+            .as_mut()
+            .expect("network sender is initialized before send")
+            .send_ipv4(plan.target(), plan.bytes(), destination, protocol)
     }
 }
 
@@ -498,11 +533,15 @@ mod tests {
     }
 
     fn ipv4_packet() -> crate::Packet {
+        ipv4_packet_to(Ipv4Addr::new(198, 51, 100, 20), "payload")
+    }
+
+    fn ipv4_packet_to(destination: Ipv4Addr, payload: &'static str) -> crate::Packet {
         Ipv4::new()
             .src(Ipv4Addr::new(192, 0, 2, 10))
-            .dst(Ipv4Addr::new(198, 51, 100, 20))
+            .dst(destination)
             / Udp::new().sport(49152).dport(53)
-            / Raw::from("payload")
+            / Raw::from(payload)
     }
 
     #[test]
@@ -761,5 +800,83 @@ mod tests {
         assert_eq!(snapshot.link_sends[1].bytes, second_plan.bytes());
         assert!(snapshot.network_opens.is_empty());
         assert!(snapshot.network_sends.is_empty());
+    }
+
+    #[test]
+    fn live_ipv4_network_sender_opens_once() {
+        let backend = FakePnetBackend::default();
+        let mut sender = PacketSender::open_with_backend(
+            SendOptions::new().iface("fake0").network_layer().live(),
+            backend.clone(),
+        )
+        .unwrap();
+
+        let first = ipv4_packet_to(Ipv4Addr::new(198, 51, 100, 20), "one");
+        let second = ipv4_packet_to(Ipv4Addr::new(203, 0, 113, 30), "two");
+        let first_report = sender.send(&first).unwrap();
+        let second_report = sender.send(&second).unwrap();
+
+        assert!(!first_report.is_dry_run());
+        assert!(!second_report.is_dry_run());
+        assert_eq!(first_report.bytes_sent(), first_report.plan().len());
+        assert_eq!(second_report.bytes_sent(), second_report.plan().len());
+
+        let snapshot = backend.snapshot();
+        assert_eq!(snapshot.network_opens.len(), 1);
+        assert_eq!(
+            snapshot.network_opens[0].socket_protocol,
+            IPPROTO_RAW_SOCKET
+        );
+        assert_eq!(snapshot.network_sends.len(), 2);
+        assert!(snapshot.link_opens.is_empty());
+        assert!(snapshot.link_sends.is_empty());
+    }
+
+    #[test]
+    fn live_ipv4_network_sender_preserves_destinations() {
+        let backend = FakePnetBackend::default();
+        let mut sender = PacketSender::open_with_backend(
+            SendOptions::new().iface("fake0").network_layer().live(),
+            backend.clone(),
+        )
+        .unwrap();
+
+        let first_destination = Ipv4Addr::new(198, 51, 100, 20);
+        let second_destination = Ipv4Addr::new(203, 0, 113, 30);
+        let first = ipv4_packet_to(first_destination, "first");
+        let second = ipv4_packet_to(second_destination, "second");
+        let first_plan = SendPlan::from_packet(
+            &first,
+            SendOptions::new().iface("fake0").network_layer().dry_run(),
+        )
+        .unwrap();
+        let second_plan = SendPlan::from_packet(
+            &second,
+            SendOptions::new().iface("fake0").network_layer().dry_run(),
+        )
+        .unwrap();
+
+        sender.send(&first).unwrap();
+        sender.send(&second).unwrap();
+
+        let snapshot = backend.snapshot();
+        assert_eq!(snapshot.network_opens.len(), 1);
+        assert_eq!(snapshot.network_sends.len(), 2);
+        assert_eq!(snapshot.network_sends[0].target, first_plan.target());
+        assert_eq!(snapshot.network_sends[0].bytes, first_plan.bytes());
+        assert_eq!(
+            snapshot.network_sends[0].destination,
+            IpAddr::V4(first_destination)
+        );
+        assert_eq!(snapshot.network_sends[0].protocol, IPPROTO_UDP);
+        assert_eq!(snapshot.network_sends[1].target, second_plan.target());
+        assert_eq!(snapshot.network_sends[1].bytes, second_plan.bytes());
+        assert_eq!(
+            snapshot.network_sends[1].destination,
+            IpAddr::V4(second_destination)
+        );
+        assert_eq!(snapshot.network_sends[1].protocol, IPPROTO_UDP);
+        assert!(snapshot.link_opens.is_empty());
+        assert!(snapshot.link_sends.is_empty());
     }
 }

--- a/crafter/src/net/packet_sender.rs
+++ b/crafter/src/net/packet_sender.rs
@@ -40,20 +40,54 @@ pub(crate) trait PnetBackend {
     ) -> Result<Self::NetworkSender>;
 }
 
-pub(crate) struct PacketSender<B: PnetBackend = PnetIoBackend> {
+/// Reusable packet sender for one explicit send class.
+///
+/// `PacketSender` keeps state across calls so repeated live sends can reuse the
+/// backend opened for a homogeneous link-layer or network-layer stream. Live
+/// senders must be opened with [`SendOptions::link_layer`] or
+/// [`SendOptions::network_layer`]; dry-run senders stay offline and only return
+/// inspectable send reports. [`crate::net::SocketSender`] remains the
+/// compatibility one-shot API for callers that do not need sender reuse.
+pub struct PacketSender {
+    inner: BackendPacketSender<PnetIoBackend>,
+}
+
+impl PacketSender {
+    /// Open a reusable packet sender from send options.
+    ///
+    /// Live senders require an explicit send class. Use
+    /// [`SendOptions::link_layer`] for Ethernet or radiotap frames, or
+    /// [`SendOptions::network_layer`] for supported network-layer packets.
+    /// Dry-run senders never open an OS raw socket.
+    pub fn open(options: impl Into<SendOptions>) -> Result<Self> {
+        BackendPacketSender::open_with_backend(options, PnetIoBackend)
+            .map(|inner| Self { inner })
+    }
+
+    /// Borrow this sender's options.
+    pub const fn options(&self) -> &SendOptions {
+        self.inner.options()
+    }
+
+    /// Compile a packet and return a send plan without transmitting bytes.
+    pub fn plan(&self, packet: &Packet) -> Result<SendPlan> {
+        self.inner.plan(packet)
+    }
+
+    /// Send a packet, or return a dry-run report when configured for dry-run.
+    pub fn send(&mut self, packet: &Packet) -> Result<SendReport> {
+        self.inner.send(packet)
+    }
+}
+
+pub(crate) struct BackendPacketSender<B: PnetBackend = PnetIoBackend> {
     options: SendOptions,
     backend: B,
     link_sender: Option<B::LinkSender>,
     network_sender: Option<B::NetworkSender>,
 }
 
-impl PacketSender<PnetIoBackend> {
-    pub(crate) fn open(options: impl Into<SendOptions>) -> Result<Self> {
-        Self::open_with_backend(options, PnetIoBackend)
-    }
-}
-
-impl<B> PacketSender<B>
+impl<B> BackendPacketSender<B>
 where
     B: PnetBackend,
 {
@@ -659,7 +693,7 @@ mod tests {
     fn packet_sender_requires_explicit_live_mode() {
         let backend = FakePnetBackend::default();
 
-        let error = match PacketSender::open_with_backend(
+        let error = match BackendPacketSender::open_with_backend(
             SendOptions::new().iface("fake0").live(),
             backend.clone(),
         ) {
@@ -686,7 +720,7 @@ mod tests {
     #[test]
     fn packet_sender_dry_run() {
         let backend = FakePnetBackend::default();
-        let mut sender = PacketSender::open_with_backend(
+        let mut sender = BackendPacketSender::open_with_backend(
             SendOptions::new().iface("fake0").dry_run(),
             backend.clone(),
         )
@@ -715,7 +749,7 @@ mod tests {
     #[test]
     fn live_link_layer_sender_opens_once() {
         let backend = FakePnetBackend::default();
-        let mut sender = PacketSender::open_with_backend(
+        let mut sender = BackendPacketSender::open_with_backend(
             SendOptions::new().iface("fake0").link_layer().live(),
             backend.clone(),
         )
@@ -741,7 +775,7 @@ mod tests {
     #[test]
     fn live_link_layer_sender_writes_ethernet_frames() {
         let backend = FakePnetBackend::default();
-        let mut sender = PacketSender::open_with_backend(
+        let mut sender = BackendPacketSender::open_with_backend(
             SendOptions::new().iface("fake0").link_layer().live(),
             backend.clone(),
         )
@@ -783,7 +817,7 @@ mod tests {
     #[test]
     fn live_link_layer_sender_writes_radiotap_frames() {
         let backend = FakePnetBackend::default();
-        let mut sender = PacketSender::open_with_backend(
+        let mut sender = BackendPacketSender::open_with_backend(
             SendOptions::new().iface("fake0").link_layer().live(),
             backend.clone(),
         )
@@ -840,7 +874,7 @@ mod tests {
     #[test]
     fn live_ipv4_network_sender_opens_once() {
         let backend = FakePnetBackend::default();
-        let mut sender = PacketSender::open_with_backend(
+        let mut sender = BackendPacketSender::open_with_backend(
             SendOptions::new().iface("fake0").network_layer().live(),
             backend.clone(),
         )
@@ -870,7 +904,7 @@ mod tests {
     #[test]
     fn live_ipv4_network_sender_preserves_destinations() {
         let backend = FakePnetBackend::default();
-        let mut sender = PacketSender::open_with_backend(
+        let mut sender = BackendPacketSender::open_with_backend(
             SendOptions::new().iface("fake0").network_layer().live(),
             backend.clone(),
         )
@@ -918,7 +952,7 @@ mod tests {
     #[test]
     fn packet_sender_rejects_mixed_send_classes() {
         let link_backend = FakePnetBackend::default();
-        let mut link_sender = PacketSender::open_with_backend(
+        let mut link_sender = BackendPacketSender::open_with_backend(
             SendOptions::new().iface("fake0").link_layer().live(),
             link_backend.clone(),
         )
@@ -948,7 +982,7 @@ mod tests {
         assert!(snapshot.network_sends.is_empty());
 
         let network_backend = FakePnetBackend::default();
-        let mut network_sender = PacketSender::open_with_backend(
+        let mut network_sender = BackendPacketSender::open_with_backend(
             SendOptions::new().iface("fake0").network_layer().live(),
             network_backend.clone(),
         )
@@ -983,7 +1017,7 @@ mod tests {
     #[test]
     fn packet_sender_rejects_unsupported_live_targets() {
         let link_backend = FakePnetBackend::default();
-        let mut link_sender = PacketSender::open_with_backend(
+        let mut link_sender = BackendPacketSender::open_with_backend(
             SendOptions::new().iface("fake0").link_layer().live(),
             link_backend.clone(),
         )
@@ -1013,7 +1047,7 @@ mod tests {
         assert!(snapshot.network_sends.is_empty());
 
         let network_backend = FakePnetBackend::default();
-        let mut network_sender = PacketSender::open_with_backend(
+        let mut network_sender = BackendPacketSender::open_with_backend(
             SendOptions::new().iface("fake0").network_layer().live(),
             network_backend.clone(),
         )

--- a/crafter/src/net/send.rs
+++ b/crafter/src/net/send.rs
@@ -269,7 +269,11 @@ impl SendReport {
     }
 }
 
-/// Raw packet sender with explicit options.
+/// One-shot raw packet sender with explicit options.
+///
+/// `SocketSender` keeps the original compatibility API for callers that send
+/// or plan one packet at a time. Use [`crate::net::PacketSender`] when repeated
+/// live sends should reuse one opened backend for an explicit send class.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SocketSender {
     options: SendOptions,

--- a/crafter/src/net/send.rs
+++ b/crafter/src/net/send.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::net::IpAddr;
 use std::time::Duration;
 
@@ -7,13 +6,9 @@ use crate::{
     CompiledPacket, Ethernet, Icmpv4, Icmpv6, Ipv4, Ipv6, Layer, LinkType, NetworkLayer, Packet,
     Radiotap, Tcp, Udp, IPPROTO_ICMP, IPPROTO_ICMPV6, IPPROTO_TCP, IPPROTO_UDP,
 };
-use pnet_datalink::{self as datalink, Channel, ChannelType};
-use pnet_packet::ip::IpNextHeaderProtocol;
-use pnet_transport::{transport_channel, TransportChannelType};
 
 use super::error::{NetError, Result};
-
-const IPPROTO_RAW_SOCKET: u8 = 255;
+use super::packet_sender;
 
 /// Caller intent for selecting a send path.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
@@ -150,6 +145,14 @@ impl SendOptions {
     /// Return true when send calls should only compile and plan.
     pub const fn is_dry_run(&self) -> bool {
         self.dry_run
+    }
+
+    pub(crate) const fn write_timeout_hint(&self) -> Option<Duration> {
+        self.write_timeout
+    }
+
+    pub(crate) const fn write_buffer_size_hint(&self) -> usize {
+        self.write_buffer_size
     }
 }
 
@@ -372,14 +375,6 @@ pub(crate) fn validated_interface(options: &SendOptions) -> Result<String> {
     Ok(interface)
 }
 
-fn net_io_error(operation: &'static str, source: io::Error) -> NetError {
-    if source.kind() == io::ErrorKind::PermissionDenied {
-        NetError::PermissionDenied { operation, source }
-    } else {
-        NetError::Io { operation, source }
-    }
-}
-
 fn infer_send_target(packet: &Packet, bytes: &[u8], mode: SendMode) -> Result<SendTarget> {
     let Some(first) = packet.get(0) else {
         return Err(NetError::UnsupportedPacketShape {
@@ -520,45 +515,10 @@ fn transmit_plan(plan: &SendPlan, options: &SendOptions) -> Result<usize> {
 
 fn transmit_link(plan: &SendPlan, options: &SendOptions, link_type: LinkType) -> Result<usize> {
     match link_type {
-        LinkType::Ethernet | LinkType::Radiotap => transmit_layer2(plan, options),
+        LinkType::Ethernet | LinkType::Radiotap => packet_sender::transmit_link_once(plan, options),
         _ => Err(NetError::UnsupportedSendTarget {
             target: plan.target,
             reason: "live link-layer send supports Ethernet and radiotap Wi-Fi frames only",
-        }),
-    }
-}
-
-fn transmit_layer2(plan: &SendPlan, options: &SendOptions) -> Result<usize> {
-    let interface = datalink::interfaces()
-        .into_iter()
-        .find(|candidate| candidate.name == plan.interface)
-        .ok_or_else(|| NetError::InterfaceNotFound {
-            name: plan.interface.clone(),
-        })?;
-
-    let config = datalink::Config {
-        channel_type: ChannelType::Layer2,
-        write_timeout: options.write_timeout,
-        write_buffer_size: options.write_buffer_size.max(plan.len()),
-        ..Default::default()
-    };
-
-    let channel = datalink::channel(&interface, config)
-        .map_err(|source| net_io_error("open datalink channel", source))?;
-
-    match channel {
-        Channel::Ethernet(mut tx, _) => {
-            let result =
-                tx.send_to(plan.bytes(), None)
-                    .ok_or_else(|| NetError::SendBufferUnavailable {
-                        interface: plan.interface.clone(),
-                        len: plan.len(),
-                    })?;
-            result.map_err(|source| net_io_error("send datalink frame", source))?;
-            Ok(plan.len())
-        }
-        _ => Err(NetError::UnsupportedDatalinkChannel {
-            interface: plan.interface.clone(),
         }),
     }
 }
@@ -570,36 +530,5 @@ fn transmit_network(
     destination: IpAddr,
     protocol: u8,
 ) -> Result<usize> {
-    // IPv4 Layer3 sends include a complete caller-compiled IP header. Opening
-    // the socket as IPPROTO_RAW keeps the header's protocol byte authoritative
-    // and avoids protocol-specific raw socket filtering of newer ICMP types.
-    let socket_protocol = match network_layer {
-        NetworkLayer::Ipv4 => IPPROTO_RAW_SOCKET,
-        NetworkLayer::Ipv6 | NetworkLayer::Raw => protocol,
-    };
-    let channel_type = TransportChannelType::Layer3(IpNextHeaderProtocol::new(socket_protocol));
-    let buffer_size = options.write_buffer_size.max(plan.len());
-    let (mut tx, _) = transport_channel(buffer_size, channel_type)
-        .map_err(|source| net_io_error("open raw network socket", source))?;
-
-    match network_layer {
-        NetworkLayer::Ipv4 => {
-            let packet = pnet_packet::ipv4::Ipv4Packet::new(plan.bytes()).ok_or({
-                NetError::UnsupportedSendTarget {
-                    target: plan.target,
-                    reason: "compiled bytes are not a complete IPv4 packet",
-                }
-            })?;
-            tx.send_to(packet, destination)
-                .map_err(|source| net_io_error("send IPv4 packet", source))
-        }
-        NetworkLayer::Ipv6 => Err(NetError::UnsupportedSendTarget {
-            target: plan.target,
-            reason: "the selected safe backend does not support full IPv6-header Layer3 sends",
-        }),
-        NetworkLayer::Raw => Err(NetError::UnsupportedSendTarget {
-            target: plan.target,
-            reason: "raw network-layer sends require an IPv4 or IPv6 header",
-        }),
-    }
+    packet_sender::transmit_network_once(plan, options, network_layer, destination, protocol)
 }

--- a/crafter/src/net/send.rs
+++ b/crafter/src/net/send.rs
@@ -310,7 +310,7 @@ impl SocketSender {
             return Ok(SendReport::new(plan, len, true));
         }
 
-        let bytes_sent = transmit_plan(&plan, &self.options)?;
+        let bytes_sent = transmit_packet_once(packet, &plan, &self.options)?;
         Ok(SendReport::new(plan, bytes_sent, false))
     }
 }
@@ -343,13 +343,13 @@ impl PacketSendExt for Packet {
     }
 
     fn send(&self, options: impl Into<SendOptions>) -> Result<SendReport> {
-        send_packet(self, options)
+        SocketSender::new(options).send(self)
     }
 }
 
 /// Compile and send a packet in one call.
 pub fn send_packet(packet: &Packet, options: impl Into<SendOptions>) -> Result<SendReport> {
-    RawSocketWriter::new(options).send_packet(packet)
+    SocketSender::new(options).send(packet)
 }
 
 /// Build a dry-run send plan in one call.
@@ -506,33 +506,20 @@ fn layer_protocol(layer: &dyn Layer) -> u8 {
     }
 }
 
-fn transmit_plan(plan: &SendPlan, options: &SendOptions) -> Result<usize> {
-    match plan.target {
-        SendTarget::LinkLayer { link_type } => transmit_link(plan, options, link_type),
-        SendTarget::NetworkLayer {
-            network_layer,
-            destination,
-            protocol,
-        } => transmit_network(plan, options, network_layer, destination, protocol),
-    }
+fn transmit_packet_once(packet: &Packet, plan: &SendPlan, options: &SendOptions) -> Result<usize> {
+    let mut sender =
+        packet_sender::PacketSender::open(one_shot_stateful_options(options, plan.target()))?;
+    let report = sender.send(packet)?;
+    Ok(report.bytes_sent())
 }
 
-fn transmit_link(plan: &SendPlan, options: &SendOptions, link_type: LinkType) -> Result<usize> {
-    match link_type {
-        LinkType::Ethernet | LinkType::Radiotap => packet_sender::transmit_link_once(plan, options),
-        _ => Err(NetError::UnsupportedSendTarget {
-            target: plan.target,
-            reason: "live link-layer send supports Ethernet and radiotap Wi-Fi frames only",
-        }),
+fn one_shot_stateful_options(options: &SendOptions, target: SendTarget) -> SendOptions {
+    if options.send_mode() != SendMode::Auto {
+        return options.clone();
     }
-}
 
-fn transmit_network(
-    plan: &SendPlan,
-    options: &SendOptions,
-    network_layer: NetworkLayer,
-    destination: IpAddr,
-    protocol: u8,
-) -> Result<usize> {
-    packet_sender::transmit_network_once(plan, options, network_layer, destination, protocol)
+    match target {
+        SendTarget::LinkLayer { .. } => options.clone().link_layer(),
+        SendTarget::NetworkLayer { .. } => options.clone().network_layer(),
+    }
 }

--- a/crafter/src/net/send_recv.rs
+++ b/crafter/src/net/send_recv.rs
@@ -4,6 +4,7 @@ use crate::wire::{PacketWire, Sniffer, WireError};
 use crate::Packet;
 
 use super::error::{NetError, Result};
+use super::packet_sender::{BackendPacketSender, PnetBackend, PnetIoBackend};
 use super::reply::{batch_reply_filter, combine_filters};
 pub use super::reply::{reply_filter, reply_matches, ReplyMatcher};
 use super::send::{validated_interface, SendMode, SendOptions, SendReport, SocketSender};
@@ -140,19 +141,49 @@ impl SendRecv {
 
     /// Send a packet and return the detailed send/receive report.
     pub fn send_recv_report(&self, packet: &Packet) -> Result<SendRecvReport> {
+        self.send_recv_report_with_pnet_backend(packet, PnetIoBackend, open_pcap_sniffer)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn send_recv_report_with_backend_and_sniffer<B, F>(
+        &self,
+        packet: &Packet,
+        backend: B,
+        open_sniffer: F,
+    ) -> Result<SendRecvReport>
+    where
+        B: PnetBackend,
+        F: FnMut(&str, Option<&str>, Duration, usize) -> Result<Sniffer>,
+    {
+        self.send_recv_report_with_pnet_backend(packet, backend, open_sniffer)
+    }
+
+    fn send_recv_report_with_pnet_backend<B, F>(
+        &self,
+        packet: &Packet,
+        backend: B,
+        mut open_sniffer: F,
+    ) -> Result<SendRecvReport>
+    where
+        B: PnetBackend,
+        F: FnMut(&str, Option<&str>, Duration, usize) -> Result<Sniffer>,
+    {
         let interface = validated_interface(&self.send_options)?;
         let matcher = ReplyMatcher::from_packet(packet);
         let effective_filter = combine_filters(matcher.reply_filter(), self.user_filter());
-        let sender = SocketSender::new(self.send_options.clone());
         let mut send_reports = Vec::new();
 
         if self.send_options.is_dry_run() {
+            let sender = SocketSender::new(self.send_options.clone());
             send_reports.push(sender.send(packet)?);
             return Ok(SendRecvReport::new(send_reports, None, effective_filter));
         }
 
+        let mut sender =
+            BackendPacketSender::open_with_backend(self.send_options.clone(), backend)?;
+
         for _ in 0..self.retries.max(1) {
-            let mut sniffer = open_pcap_sniffer(
+            let mut sniffer = open_sniffer(
                 &interface,
                 effective_filter.as_deref(),
                 self.timeout,

--- a/crafter/src/net/send_recv.rs
+++ b/crafter/src/net/send_recv.rs
@@ -487,10 +487,8 @@ impl BatchSendRecv {
         }
 
         let interface = validated_interface(self.send_recv.send_options())?;
-        let mut sender = BackendPacketSender::open_with_backend(
-            self.send_recv.send_options().clone(),
-            backend,
-        )?;
+        let mut sender =
+            BackendPacketSender::open_with_backend(self.send_recv.send_options().clone(), backend)?;
         for packet in packets {
             sender.plan(packet)?;
         }

--- a/crafter/src/net/send_recv.rs
+++ b/crafter/src/net/send_recv.rs
@@ -423,6 +423,33 @@ impl BatchSendRecv {
 
     /// Send every request and collect matching replies in request order.
     pub fn send_recv_all(&self, packets: &[Packet]) -> Result<BatchSendRecvReport> {
+        self.send_recv_all_with_pnet_backend(packets, PnetIoBackend, open_pcap_sniffer)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn send_recv_all_with_backend_and_sniffer<B, F>(
+        &self,
+        packets: &[Packet],
+        backend: B,
+        open_sniffer: F,
+    ) -> Result<BatchSendRecvReport>
+    where
+        B: PnetBackend,
+        F: FnMut(&str, Option<&str>, Duration, usize) -> Result<Sniffer>,
+    {
+        self.send_recv_all_with_pnet_backend(packets, backend, open_sniffer)
+    }
+
+    fn send_recv_all_with_pnet_backend<B, F>(
+        &self,
+        packets: &[Packet],
+        backend: B,
+        mut open_sniffer: F,
+    ) -> Result<BatchSendRecvReport>
+    where
+        B: PnetBackend,
+        F: FnMut(&str, Option<&str>, Duration, usize) -> Result<Sniffer>,
+    {
         let mut entries = (0..packets.len())
             .map(BatchSendRecvEntry::new)
             .collect::<Vec<_>>();
@@ -438,9 +465,8 @@ impl BatchSendRecv {
             ));
         }
 
-        let sender = SocketSender::new(self.send_recv.send_options().clone());
-
         if self.send_recv.send_options().is_dry_run() {
+            let sender = SocketSender::new(self.send_recv.send_options().clone());
             for chunk_start in (0..packets.len()).step_by(self.concurrency_limit) {
                 let chunk_end = (chunk_start + self.concurrency_limit).min(packets.len());
                 for _ in 0..self.send_recv.retries_value().max(1) {
@@ -461,6 +487,14 @@ impl BatchSendRecv {
         }
 
         let interface = validated_interface(self.send_recv.send_options())?;
+        let mut sender = BackendPacketSender::open_with_backend(
+            self.send_recv.send_options().clone(),
+            backend,
+        )?;
+        for packet in packets {
+            sender.plan(packet)?;
+        }
+
         for chunk_start in (0..packets.len()).step_by(self.concurrency_limit) {
             let chunk_end = (chunk_start + self.concurrency_limit).min(packets.len());
             for _ in 0..self.send_recv.retries_value().max(1) {
@@ -471,7 +505,7 @@ impl BatchSendRecv {
                     break;
                 }
 
-                let mut sniffer = open_pcap_sniffer(
+                let mut sniffer = open_sniffer(
                     &interface,
                     effective_filter.as_deref(),
                     self.send_recv.timeout_value(),

--- a/crafter/src/net/tests.rs
+++ b/crafter/src/net/tests.rs
@@ -1754,6 +1754,83 @@ mod batch_send {
 }
 
 #[cfg(test)]
+mod send_recv_live {
+    use std::net::Ipv4Addr;
+    use std::time::Duration;
+
+    use crate::net::packet_sender::FakePnetBackend;
+    use crate::net::{SendMode, SendRecv, SendTarget};
+    use crate::wire::{Sniffer, VecPacketSource};
+    use crate::{Icmpv4, Ipv4, NetworkLayer, Packet, Raw};
+
+    fn echo_request(sequence: u16) -> Packet {
+        Ipv4::new()
+            .src(Ipv4Addr::new(192, 0, 2, 10))
+            .dst(Ipv4Addr::new(198, 51, 100, 20))
+            / Icmpv4::echo_request().id(0x4242).seq(sequence)
+            / Raw::from_bytes(sequence.to_be_bytes())
+    }
+
+    #[test]
+    fn send_recv_live_reuses_packet_sender_for_retries() {
+        let backend = FakePnetBackend::default();
+        let request = echo_request(7);
+        let timeout = Duration::from_millis(10);
+        let expected_filter = "icmp and src host 198.51.100.20 and dst host 192.0.2.10";
+        let mut capture_opens = 0;
+
+        let report = SendRecv::new()
+            .iface("fake0")
+            .network_layer()
+            .live()
+            .retry(2)
+            .timeout(timeout)
+            .capture_limit(5)
+            .send_recv_report_with_backend_and_sniffer(
+                &request,
+                backend.clone(),
+                |interface, filter, capture_timeout, count| {
+                    capture_opens += 1;
+                    assert_eq!(interface, "fake0");
+                    assert_eq!(filter, Some(expected_filter));
+                    assert_eq!(capture_timeout, timeout);
+                    assert_eq!(count, 5);
+                    Ok(Sniffer::new(VecPacketSource::empty())
+                        .timeout(capture_timeout)
+                        .count(count))
+                },
+            )
+            .unwrap();
+
+        assert_eq!(capture_opens, 2);
+        assert_eq!(report.attempts(), 2);
+        assert!(report.timed_out());
+        assert!(report.reply().is_none());
+        assert_eq!(report.effective_filter(), Some(expected_filter));
+
+        for send_report in report.send_reports() {
+            assert!(!send_report.is_dry_run());
+            assert_eq!(send_report.bytes_sent(), send_report.plan().len());
+            assert_eq!(send_report.plan().interface(), "fake0");
+            assert_eq!(send_report.plan().requested_mode(), SendMode::NetworkLayer);
+            assert!(matches!(
+                send_report.plan().target(),
+                SendTarget::NetworkLayer {
+                    network_layer: NetworkLayer::Ipv4,
+                    ..
+                }
+            ));
+        }
+
+        let snapshot = backend.snapshot();
+        assert_eq!(snapshot.network_opens.len(), 1);
+        assert_eq!(snapshot.network_sends.len(), 2);
+        assert!(snapshot.link_opens.is_empty());
+        assert!(snapshot.link_sends.is_empty());
+    }
+}
+
+#[cfg(test)]
 mod batch_send_recv {
     use std::net::Ipv4Addr;
     use std::time::Duration;

--- a/crafter/src/net/tests.rs
+++ b/crafter/src/net/tests.rs
@@ -1503,7 +1503,10 @@ mod batch_send {
 
     use crate::{Ipv4, Packet, Raw, Udp};
 
-    use crate::net::{send_packets, BatchSend, PacketBatchSendExt, SendTarget};
+    use crate::net::packet_sender::FakePnetBackend;
+    use crate::net::{
+        send_packets, BatchSend, NetError, PacketBatchSendExt, SendMode, SendTarget,
+    };
 
     fn udp_request(index: u8) -> Packet {
         Ipv4::new()
@@ -1545,6 +1548,70 @@ mod batch_send {
                 ));
             }
         }
+    }
+
+    #[test]
+    fn batch_send_live_network_layer_reuses_packet_sender() {
+        let backend = FakePnetBackend::default();
+        let packets = vec![udp_request(10), udp_request(11)];
+
+        let report = BatchSend::new()
+            .iface("fake0")
+            .network_layer()
+            .live()
+            .concurrency_limit(2)
+            .retry(3)
+            .send_all_with_backend(&packets, backend.clone())
+            .unwrap();
+
+        assert!(!report.is_dry_run());
+        assert_eq!(report.len(), 2);
+        assert_eq!(report.retries(), 3);
+        for (index, entry) in report.entries().iter().enumerate() {
+            assert_eq!(entry.request_index(), index);
+            assert_eq!(entry.attempts(), 3);
+            for send_report in entry.send_reports() {
+                assert!(!send_report.is_dry_run());
+                assert_eq!(send_report.bytes_sent(), send_report.plan().len());
+                assert!(matches!(
+                    send_report.plan().target(),
+                    SendTarget::NetworkLayer { .. }
+                ));
+            }
+        }
+
+        let snapshot = backend.snapshot();
+        assert_eq!(snapshot.network_opens.len(), 1);
+        assert_eq!(snapshot.network_sends.len(), packets.len() * 3);
+        assert!(snapshot.link_opens.is_empty());
+        assert!(snapshot.link_sends.is_empty());
+    }
+
+    #[test]
+    fn batch_send_live_auto_requires_explicit_mode() {
+        let backend = FakePnetBackend::default();
+        let packets = vec![udp_request(9)];
+
+        let error = BatchSend::new()
+            .iface("fake0")
+            .live()
+            .send_all_with_backend(&packets, backend.clone())
+            .unwrap_err();
+
+        match error {
+            NetError::ExplicitSendModeRequired { mode, reason } => {
+                assert_eq!(mode, SendMode::Auto);
+                assert!(reason.contains("link_layer()"));
+                assert!(reason.contains("network_layer()"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+
+        let snapshot = backend.snapshot();
+        assert!(snapshot.link_opens.is_empty());
+        assert!(snapshot.network_opens.is_empty());
+        assert!(snapshot.link_sends.is_empty());
+        assert!(snapshot.network_sends.is_empty());
     }
 
     #[test]

--- a/crafter/src/net/tests.rs
+++ b/crafter/src/net/tests.rs
@@ -1504,9 +1504,7 @@ mod batch_send {
     use crate::{Dot11, Ethernet, Ipv4, LinkType, LlcSnap, Packet, Radiotap, Raw, Udp};
 
     use crate::net::packet_sender::FakePnetBackend;
-    use crate::net::{
-        send_packets, BatchSend, NetError, PacketBatchSendExt, SendMode, SendTarget,
-    };
+    use crate::net::{send_packets, BatchSend, NetError, PacketBatchSendExt, SendMode, SendTarget};
 
     fn udp_request(index: u8) -> Packet {
         Ipv4::new()

--- a/crafter/src/net/tests.rs
+++ b/crafter/src/net/tests.rs
@@ -261,6 +261,7 @@ mod send_plan {
             .unwrap();
 
         assert_eq!(plan.interface(), "veth0");
+        assert_eq!(plan.requested_mode(), SendMode::Auto);
         assert!(plan.target().is_link_layer());
         assert_eq!(
             plan.target(),
@@ -269,6 +270,26 @@ mod send_plan {
             }
         );
         assert_eq!(plan.bytes()[12..14], crate::ETHERTYPE_IPV4.to_be_bytes());
+    }
+
+    #[test]
+    fn send_plan_explicit_link_layer_preserves_ethernet_target() {
+        let packet = Ethernet::new() / ipv4_packet();
+        let plan = packet
+            .send_dry_run(SendOptions::new().iface("veth0").link_layer())
+            .unwrap();
+
+        assert_eq!(plan.interface(), "veth0");
+        assert_eq!(plan.requested_mode(), SendMode::LinkLayer);
+        assert!(plan.target().is_link_layer());
+        assert_eq!(
+            plan.target(),
+            SendTarget::LinkLayer {
+                link_type: crate::LinkType::Ethernet
+            }
+        );
+        assert_eq!(plan.bytes()[12..14], crate::ETHERTYPE_IPV4.to_be_bytes());
+        assert_eq!(plan.len(), packet.compile().unwrap().len());
     }
 
     #[test]
@@ -331,6 +352,15 @@ mod send_plan {
 
         assert_eq!(plan.requested_mode(), SendMode::NetworkLayer);
         assert!(plan.target().is_network_layer());
+        assert_eq!(plan.bytes(), packet.compile().unwrap().as_bytes());
+        assert_eq!(
+            plan.target(),
+            SendTarget::NetworkLayer {
+                network_layer: NetworkLayer::Ipv4,
+                destination: IpAddr::V4(Ipv4Addr::new(198, 51, 100, 20)),
+                protocol: crate::IPPROTO_UDP
+            }
+        );
     }
 
     #[test]
@@ -450,6 +480,9 @@ mod send_plan {
             .send_dry_run(SendOptions::new().iface("lo").network_layer())
             .unwrap();
 
+        assert_eq!(plan.interface(), "lo");
+        assert_eq!(plan.requested_mode(), SendMode::NetworkLayer);
+        assert_eq!(plan.bytes(), packet.compile().unwrap().as_bytes());
         match plan.target() {
             SendTarget::NetworkLayer {
                 network_layer,
@@ -462,6 +495,13 @@ mod send_plan {
             }
             _ => panic!("expected IPv6 network-layer send target"),
         }
+
+        let report = SocketSender::new(SendOptions::new().iface("lo").network_layer().dry_run())
+            .send(&packet)
+            .unwrap();
+        assert!(report.is_dry_run());
+        assert_eq!(report.bytes_sent(), plan.len());
+        assert_eq!(report.plan().target(), plan.target());
     }
 }
 
@@ -469,7 +509,7 @@ mod send_plan {
 mod send_errors {
     use crate::{Ethernet, Ipv4, Packet, Raw};
 
-    use crate::net::{NetError, PacketSendExt, SendOptions, SocketSender};
+    use crate::net::{NetError, PacketSendExt, SendMode, SendOptions, SocketSender};
 
     #[test]
     fn send_plan_requires_interface() {
@@ -500,23 +540,50 @@ mod send_errors {
     }
 
     #[test]
-    fn link_layer_intent_rejects_network_packet() {
+    fn send_plan_link_layer_intent_rejects_bare_ipv4_packet() {
         let packet = Ipv4::new() / Raw::from("payload");
         let error = packet
             .send_plan(SendOptions::new().iface("eth0").link_layer().dry_run())
             .unwrap_err();
 
-        assert!(matches!(error, NetError::UnsupportedPacketShape { .. }));
+        match error {
+            NetError::UnsupportedPacketShape {
+                mode,
+                summary: _,
+                reason,
+            } => {
+                assert_eq!(mode, SendMode::LinkLayer);
+                assert_eq!(
+                    reason,
+                    "link-layer sends require Ethernet, LinuxSll, NullLoopback, or Radiotap / Dot11 Wi-Fi as the first layers"
+                );
+            }
+            other => panic!("expected unsupported packet shape, got {other}"),
+        }
     }
 
     #[test]
-    fn network_layer_intent_rejects_link_packet() {
+    fn send_plan_network_layer_intent_rejects_ethernet_frame() {
         let packet = Ethernet::new() / Ipv4::new() / Raw::from("payload");
         let error = packet
             .send_plan(SendOptions::new().iface("eth0").network_layer().dry_run())
             .unwrap_err();
 
-        assert!(matches!(error, NetError::UnsupportedPacketShape { .. }));
+        match error {
+            NetError::UnsupportedPacketShape {
+                mode,
+                summary,
+                reason,
+            } => {
+                assert_eq!(mode, SendMode::NetworkLayer);
+                assert!(summary.contains("Ethernet"));
+                assert_eq!(
+                    reason,
+                    "network-layer sends require IPv4 or IPv6 as the first layer"
+                );
+            }
+            other => panic!("expected unsupported packet shape, got {other}"),
+        }
     }
 
     #[test]

--- a/crafter/src/net/tests.rs
+++ b/crafter/src/net/tests.rs
@@ -1837,7 +1837,9 @@ mod batch_send_recv {
 
     use crate::{Icmpv4, Ipv4, NetworkLayer, Packet, Raw};
 
-    use crate::net::{BatchSendRecv, PacketBatchSendRecvExt};
+    use crate::net::packet_sender::FakePnetBackend;
+    use crate::net::{BatchSendRecv, NetError, PacketBatchSendRecvExt, SendMode, SendTarget};
+    use crate::wire::{Sniffer, VecPacketSource};
 
     fn echo_request(sequence: u16) -> Packet {
         Ipv4::new()
@@ -1888,6 +1890,106 @@ mod batch_send_recv {
             assert_eq!(entry.attempts(), 2);
             assert!(entry.timed_out());
         }
+    }
+
+    #[test]
+    fn batch_send_recv_live_reuses_packet_sender() {
+        let backend = FakePnetBackend::default();
+        let requests = vec![echo_request(1), echo_request(2), echo_request(3)];
+        let timeout = Duration::from_millis(10);
+        let expected_filter = "icmp and src host 198.51.100.20 and dst host 192.0.2.10";
+        let mut capture_opens = 0;
+        let mut capture_counts = Vec::new();
+
+        let report = BatchSendRecv::new()
+            .iface("fake0")
+            .network_layer()
+            .live()
+            .concurrency_limit(2)
+            .retry(2)
+            .timeout(timeout)
+            .capture_limit(2)
+            .send_recv_all_with_backend_and_sniffer(
+                &requests,
+                backend.clone(),
+                |interface, filter, capture_timeout, count| {
+                    capture_opens += 1;
+                    capture_counts.push(count);
+                    assert_eq!(interface, "fake0");
+                    assert_eq!(filter, Some(expected_filter));
+                    assert_eq!(capture_timeout, timeout);
+                    Ok(Sniffer::new(VecPacketSource::empty())
+                        .timeout(capture_timeout)
+                        .count(count))
+                },
+            )
+            .unwrap();
+
+        assert_eq!(capture_opens, 4);
+        assert_eq!(capture_counts, vec![4, 4, 2, 2]);
+        assert_eq!(report.len(), requests.len());
+        assert_eq!(report.concurrency_limit(), 2);
+        assert_eq!(report.retries(), 2);
+        assert_eq!(report.reply_count(), 0);
+        assert_eq!(report.timed_out_indices(), vec![0, 1, 2]);
+        assert_eq!(report.effective_filter(), Some(expected_filter));
+
+        for (index, entry) in report.entries().iter().enumerate() {
+            assert_eq!(entry.request_index(), index);
+            assert_eq!(entry.attempts(), 2);
+            assert!(entry.timed_out());
+            for send_report in entry.send_reports() {
+                assert!(!send_report.is_dry_run());
+                assert_eq!(send_report.bytes_sent(), send_report.plan().len());
+                assert_eq!(send_report.plan().interface(), "fake0");
+                assert_eq!(send_report.plan().requested_mode(), SendMode::NetworkLayer);
+                assert!(matches!(
+                    send_report.plan().target(),
+                    SendTarget::NetworkLayer {
+                        network_layer: NetworkLayer::Ipv4,
+                        ..
+                    }
+                ));
+            }
+        }
+
+        let snapshot = backend.snapshot();
+        assert_eq!(snapshot.network_opens.len(), 1);
+        assert_eq!(snapshot.network_sends.len(), requests.len() * 2);
+        assert!(snapshot.link_opens.is_empty());
+        assert!(snapshot.link_sends.is_empty());
+
+        let wrong_backend = FakePnetBackend::default();
+        let mut wrong_capture_opens = 0;
+        let wrong_error = BatchSendRecv::new()
+            .iface("fake0")
+            .link_layer()
+            .live()
+            .send_recv_all_with_backend_and_sniffer(
+                &[echo_request(9)],
+                wrong_backend.clone(),
+                |_, _, capture_timeout, count| {
+                    wrong_capture_opens += 1;
+                    Ok(Sniffer::new(VecPacketSource::empty())
+                        .timeout(capture_timeout)
+                        .count(count))
+                },
+            )
+            .unwrap_err();
+
+        match wrong_error {
+            NetError::UnsupportedPacketShape { mode, reason, .. } => {
+                assert_eq!(mode, SendMode::LinkLayer);
+                assert!(reason.contains("link-layer sends require"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+        assert_eq!(wrong_capture_opens, 0);
+        let wrong_snapshot = wrong_backend.snapshot();
+        assert!(wrong_snapshot.link_opens.is_empty());
+        assert!(wrong_snapshot.link_sends.is_empty());
+        assert!(wrong_snapshot.network_opens.is_empty());
+        assert!(wrong_snapshot.network_sends.is_empty());
     }
 
     #[test]

--- a/crafter/src/net/tests.rs
+++ b/crafter/src/net/tests.rs
@@ -1501,7 +1501,7 @@ mod batch_send {
     use std::net::Ipv4Addr;
     use std::time::Duration;
 
-    use crate::{Ipv4, Packet, Raw, Udp};
+    use crate::{Dot11, Ethernet, Ipv4, LinkType, LlcSnap, Packet, Radiotap, Raw, Udp};
 
     use crate::net::packet_sender::FakePnetBackend;
     use crate::net::{
@@ -1514,6 +1514,14 @@ mod batch_send {
             .dst(Ipv4Addr::new(198, 51, 100, index))
             / Udp::new().sport(40_000 + u16::from(index)).dport(3_344)
             / Raw::from_bytes([index, index + 1])
+    }
+
+    fn ethernet_request(index: u8) -> Packet {
+        Ethernet::new() / udp_request(index)
+    }
+
+    fn radiotap_request(index: u8) -> Packet {
+        Radiotap::new() / Dot11::data() / LlcSnap::new() / udp_request(index)
     }
 
     #[test]
@@ -1585,6 +1593,114 @@ mod batch_send {
         assert_eq!(snapshot.network_sends.len(), packets.len() * 3);
         assert!(snapshot.link_opens.is_empty());
         assert!(snapshot.link_sends.is_empty());
+    }
+
+    #[test]
+    fn batch_send_live_link_layer_reuses_packet_sender() {
+        let ethernet_backend = FakePnetBackend::default();
+        let ethernet_packets = vec![ethernet_request(20), ethernet_request(21)];
+
+        let ethernet_report = BatchSend::new()
+            .iface("fake0")
+            .link_layer()
+            .live()
+            .send_all_with_backend(&ethernet_packets, ethernet_backend.clone())
+            .unwrap();
+
+        assert!(!ethernet_report.is_dry_run());
+        assert_eq!(ethernet_report.len(), ethernet_packets.len());
+        for (index, entry) in ethernet_report.entries().iter().enumerate() {
+            assert_eq!(entry.request_index(), index);
+            assert_eq!(entry.attempts(), 1);
+            assert_eq!(entry.send_reports().len(), 1);
+            let send_report = &entry.send_reports()[0];
+            assert!(!send_report.is_dry_run());
+            assert_eq!(send_report.bytes_sent(), send_report.plan().len());
+            assert_eq!(
+                send_report.plan().target(),
+                SendTarget::LinkLayer {
+                    link_type: LinkType::Ethernet,
+                }
+            );
+        }
+
+        let snapshot = ethernet_backend.snapshot();
+        assert_eq!(snapshot.link_opens.len(), 1);
+        assert_eq!(
+            snapshot.link_opens[0].target,
+            SendTarget::LinkLayer {
+                link_type: LinkType::Ethernet,
+            }
+        );
+        assert_eq!(snapshot.link_sends.len(), ethernet_packets.len());
+        assert!(snapshot.network_opens.is_empty());
+        assert!(snapshot.network_sends.is_empty());
+
+        let radiotap_backend = FakePnetBackend::default();
+        let radiotap_packets = vec![radiotap_request(30), radiotap_request(31)];
+
+        let radiotap_report = BatchSend::new()
+            .iface("fake0")
+            .link_layer()
+            .live()
+            .send_all_with_backend(&radiotap_packets, radiotap_backend.clone())
+            .unwrap();
+
+        assert!(!radiotap_report.is_dry_run());
+        assert_eq!(radiotap_report.len(), radiotap_packets.len());
+        for (index, entry) in radiotap_report.entries().iter().enumerate() {
+            assert_eq!(entry.request_index(), index);
+            assert_eq!(entry.attempts(), 1);
+            assert_eq!(entry.send_reports().len(), 1);
+            let send_report = &entry.send_reports()[0];
+            assert!(!send_report.is_dry_run());
+            assert_eq!(send_report.bytes_sent(), send_report.plan().len());
+            assert_eq!(
+                send_report.plan().target(),
+                SendTarget::LinkLayer {
+                    link_type: LinkType::Radiotap,
+                }
+            );
+        }
+
+        let snapshot = radiotap_backend.snapshot();
+        assert_eq!(snapshot.link_opens.len(), 1);
+        assert_eq!(
+            snapshot.link_opens[0].target,
+            SendTarget::LinkLayer {
+                link_type: LinkType::Radiotap,
+            }
+        );
+        assert_eq!(snapshot.link_sends.len(), radiotap_packets.len());
+        assert!(snapshot.network_opens.is_empty());
+        assert!(snapshot.network_sends.is_empty());
+    }
+
+    #[test]
+    fn batch_send_live_link_layer_rejects_network_packet() {
+        let backend = FakePnetBackend::default();
+        let packets = vec![udp_request(40)];
+
+        let error = BatchSend::new()
+            .iface("fake0")
+            .link_layer()
+            .live()
+            .send_all_with_backend(&packets, backend.clone())
+            .unwrap_err();
+
+        match error {
+            NetError::UnsupportedPacketShape { mode, reason, .. } => {
+                assert_eq!(mode, SendMode::LinkLayer);
+                assert!(reason.contains("link-layer sends require"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+
+        let snapshot = backend.snapshot();
+        assert!(snapshot.link_opens.is_empty());
+        assert!(snapshot.link_sends.is_empty());
+        assert!(snapshot.network_opens.is_empty());
+        assert!(snapshot.network_sends.is_empty());
     }
 
     #[test]

--- a/crafter/src/net/tests.rs
+++ b/crafter/src/net/tests.rs
@@ -396,6 +396,45 @@ mod send_plan {
             one_shot_report.plan().target(),
             extension_report.plan().target()
         );
+
+        let ethernet_packet = Ethernet::new() / ipv4_packet();
+        let ethernet_report = SocketSender::dry_run("veth0")
+            .send(&ethernet_packet)
+            .unwrap();
+        assert!(ethernet_report.is_dry_run());
+        assert_eq!(ethernet_report.bytes_sent(), ethernet_report.plan().len());
+        assert_eq!(ethernet_report.plan().requested_mode(), SendMode::Auto);
+        assert_eq!(
+            ethernet_report.plan().target(),
+            SendTarget::LinkLayer {
+                link_type: crate::LinkType::Ethernet
+            }
+        );
+
+        let ipv6_packet = Ipv6::new()
+            .src(Ipv6Addr::LOCALHOST)
+            .dst(Ipv6Addr::LOCALHOST)
+            / Tcp::new().sport(1234).dport(443);
+        let error = SocketSender::new(SendOptions::new().iface("lo").network_layer().live())
+            .send(&ipv6_packet)
+            .unwrap_err();
+        match error {
+            NetError::UnsupportedSendTarget { target, reason } => {
+                assert_eq!(
+                    target,
+                    SendTarget::NetworkLayer {
+                        network_layer: NetworkLayer::Ipv6,
+                        destination: IpAddr::V6(Ipv6Addr::LOCALHOST),
+                        protocol: crate::IPPROTO_TCP
+                    }
+                );
+                assert_eq!(
+                    reason,
+                    "the selected safe backend does not support full IPv6-header Layer3 sends"
+                );
+            }
+            other => panic!("expected unsupported IPv6 live network-layer send, got {other}"),
+        }
     }
 
     #[test]
@@ -422,6 +461,21 @@ mod send_plan {
                 assert_eq!(name, "missing-crafter-wifi0");
             }
             other => panic!("expected radiotap live send to report missing interface, got {other}"),
+        }
+
+        let error = one_shot_send_packet(
+            &packet,
+            SendOptions::new().iface("missing-crafter-wifi0").live(),
+        )
+        .unwrap_err();
+
+        match error {
+            NetError::InterfaceNotFound { name } => {
+                assert_eq!(name, "missing-crafter-wifi0");
+            }
+            other => {
+                panic!("expected one-shot radiotap send to report missing interface, got {other}")
+            }
         }
     }
 

--- a/crafter/src/wire/backend/raw_socket.rs
+++ b/crafter/src/wire/backend/raw_socket.rs
@@ -1,5 +1,9 @@
 //! Raw socket packet writer adapter.
 
+use std::cell::RefCell;
+use std::fmt;
+
+use crate::net::packet_sender::{BackendPacketSender, PnetBackend, PnetIoBackend};
 use crate::net::{
     Result as NetResult, SendMode, SendOptions, SendPlan, SendReport, SendTarget, SocketSender,
 };
@@ -10,15 +14,13 @@ use super::super::record::{BackendKind, PacketRecord};
 use super::super::writer::{PacketWriter, WriteReport};
 use super::super::Result;
 
-/// Packet writer that adapts [`SocketSender`] into the [`PacketWriter`] API.
+/// Packet writer that adapts raw socket sending into the [`PacketWriter`] API.
 ///
-/// The adapter delegates planning, dry-run behavior, live transmission,
-/// interface validation, send-mode handling, and unsupported target checks to
-/// `SocketSender`. In particular, live radiotap injection is routed through the
-/// same Layer-2 datalink writer `SocketSender` uses for Ethernet frames.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// The adapter keeps [`SocketSender`] inspection compatibility while routing
+/// actual writes through a stateful packet sender. Repeated live writes through
+/// one writer reuse the opened backend for the configured send class.
 pub struct RawSocketWriter {
-    sender: SocketSender,
+    inner: StatefulRawSocketWriter<PnetIoBackend>,
 }
 
 impl RawSocketWriter {
@@ -29,9 +31,7 @@ impl RawSocketWriter {
     /// when you want the packet-wire constructor that defaults to dry-run
     /// planning and requires `.live()` for live transmission.
     pub fn new(options: impl Into<SendOptions>) -> Self {
-        Self {
-            sender: SocketSender::new(options),
-        }
+        Self::from(SocketSender::new(options))
     }
 
     /// Create a compile-only raw socket writer for an interface.
@@ -46,35 +46,145 @@ impl RawSocketWriter {
 
     /// Borrow the adapted sender.
     pub const fn sender(&self) -> &SocketSender {
-        &self.sender
+        self.inner.sender()
     }
 
     /// Borrow the adapted sender options.
     pub const fn options(&self) -> &SendOptions {
-        self.sender.options()
+        self.inner.options()
     }
 
     /// Build the send plan this writer would use for a packet.
     pub fn plan_packet(&self, packet: &Packet) -> NetResult<SendPlan> {
-        self.sender.plan(packet)
+        self.inner.plan_packet(packet)
     }
 
     /// Send a packet through the adapted raw socket sender.
     pub fn send_packet(&self, packet: &Packet) -> NetResult<SendReport> {
-        self.sender.send(packet)
+        self.inner.send_packet(packet)
     }
 }
 
+impl fmt::Debug for RawSocketWriter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RawSocketWriter")
+            .field("sender", self.sender())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Clone for RawSocketWriter {
+    fn clone(&self) -> Self {
+        Self::from(self.sender().clone())
+    }
+}
+
+impl PartialEq for RawSocketWriter {
+    fn eq(&self, other: &Self) -> bool {
+        self.sender() == other.sender()
+    }
+}
+
+impl Eq for RawSocketWriter {}
+
 impl From<SocketSender> for RawSocketWriter {
     fn from(sender: SocketSender) -> Self {
-        Self { sender }
+        Self {
+            inner: StatefulRawSocketWriter::from_sender_with_backend(sender, PnetIoBackend),
+        }
     }
 }
 
 impl PacketWriter for RawSocketWriter {
     fn write_record(&mut self, record: &PacketRecord) -> Result<WriteReport> {
+        self.inner.write_record(record)
+    }
+}
+
+struct StatefulRawSocketWriter<B>
+where
+    B: PnetBackend + Clone,
+{
+    sender: SocketSender,
+    stateful_sender: RefCell<StatefulPacketSender<B>>,
+}
+
+impl<B> StatefulRawSocketWriter<B>
+where
+    B: PnetBackend + Clone,
+{
+    #[cfg(test)]
+    fn new_with_backend(options: impl Into<SendOptions>, backend: B) -> Self {
+        Self::from_sender_with_backend(SocketSender::new(options), backend)
+    }
+
+    fn from_sender_with_backend(sender: SocketSender, backend: B) -> Self {
+        Self {
+            sender,
+            stateful_sender: RefCell::new(StatefulPacketSender::new(backend)),
+        }
+    }
+
+    const fn sender(&self) -> &SocketSender {
+        &self.sender
+    }
+
+    const fn options(&self) -> &SendOptions {
+        self.sender.options()
+    }
+
+    fn plan_packet(&self, packet: &Packet) -> NetResult<SendPlan> {
+        self.sender.plan(packet)
+    }
+
+    fn send_packet(&self, packet: &Packet) -> NetResult<SendReport> {
+        self.stateful_sender
+            .borrow_mut()
+            .send(self.sender.options(), packet)
+    }
+}
+
+impl<B> PacketWriter for StatefulRawSocketWriter<B>
+where
+    B: PnetBackend + Clone,
+{
+    fn write_record(&mut self, record: &PacketRecord) -> Result<WriteReport> {
         let send_report = self.send_packet(record.packet())?;
         Ok(write_report_from_send_report(&send_report))
+    }
+}
+
+struct StatefulPacketSender<B>
+where
+    B: PnetBackend + Clone,
+{
+    backend: B,
+    sender: Option<BackendPacketSender<B>>,
+}
+
+impl<B> StatefulPacketSender<B>
+where
+    B: PnetBackend + Clone,
+{
+    fn new(backend: B) -> Self {
+        Self {
+            backend,
+            sender: None,
+        }
+    }
+
+    fn send(&mut self, options: &SendOptions, packet: &Packet) -> NetResult<SendReport> {
+        if self.sender.is_none() {
+            self.sender = Some(BackendPacketSender::open_with_backend(
+                options.clone(),
+                self.backend.clone(),
+            )?);
+        }
+
+        self.sender
+            .as_mut()
+            .expect("stateful raw socket sender is initialized before send")
+            .send(packet)
     }
 }
 
@@ -148,6 +258,7 @@ mod raw_socket_writer {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     use super::*;
+    use crate::net::packet_sender::{FakePnetBackend, IPPROTO_RAW_SOCKET};
     use crate::net::{NetError, SendMode, SendOptions, SendTarget};
     use crate::{
         Dot11, Ethernet, Ipv4, Ipv6, LlcSnap, MacAddr, Packet, PacketWire, PacketWireTarget,
@@ -356,8 +467,12 @@ mod raw_socket_writer {
 
     #[test]
     fn raw_socket_writer_live_radiotap_routes_to_layer2_via_socket_sender() {
-        let mut writer =
-            RawSocketWriter::new(SendOptions::new().interface("missing-crafter-wifi0").live());
+        let mut writer = RawSocketWriter::new(
+            SendOptions::new()
+                .interface("missing-crafter-wifi0")
+                .link_layer()
+                .live(),
+        );
         let error = writer
             .write_record(&PacketRecord::new(radiotap_dot11_packet()))
             .unwrap_err();
@@ -368,6 +483,63 @@ mod raw_socket_writer {
             }
             other => panic!("expected raw socket radiotap missing-interface error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn raw_socket_writer_live_network_layer_reuses_open_sender() {
+        let backend = FakePnetBackend::default();
+        let mut writer = StatefulRawSocketWriter::new_with_backend(
+            SendOptions::new()
+                .interface("lo")
+                .network_layer()
+                .live()
+                .write_buffer_size(8),
+            backend.clone(),
+        );
+        let packet = ipv4_packet();
+        let expected_len = packet.compile().unwrap().len();
+
+        let first_report = writer
+            .write_record(&PacketRecord::new(packet.clone()))
+            .unwrap();
+        let second_report = writer
+            .write_record(&PacketRecord::new(packet.clone()))
+            .unwrap();
+
+        for report in [&first_report, &second_report] {
+            assert_eq!(report.backend(), &BackendKind::RawSocket);
+            assert_eq!(report.bytes_requested(), expected_len);
+            assert_eq!(report.bytes_written(), expected_len);
+            assert!(!report.is_dry_run());
+            assert_eq!(
+                report.target_details(),
+                Some(
+                    "interface=lo mode=network-layer target=network-layer:ipv4 destination=198.51.100.20 protocol=17"
+                )
+            );
+        }
+
+        let snapshot = backend.snapshot();
+        assert_eq!(snapshot.link_opens.len(), 0);
+        assert_eq!(snapshot.link_sends.len(), 0);
+        assert_eq!(snapshot.network_opens.len(), 1);
+        assert_eq!(
+            snapshot.network_opens[0].socket_protocol,
+            IPPROTO_RAW_SOCKET
+        );
+        assert_eq!(snapshot.network_opens[0].write_buffer_size, expected_len);
+        assert_eq!(snapshot.network_sends.len(), 2);
+        assert_eq!(snapshot.network_sends[0].bytes.len(), expected_len);
+        assert_eq!(snapshot.network_sends[1].bytes.len(), expected_len);
+        assert_eq!(
+            snapshot.network_sends[0].destination,
+            IpAddr::V4(Ipv4Addr::new(198, 51, 100, 20))
+        );
+        assert_eq!(snapshot.network_sends[0].protocol, crate::IPPROTO_UDP);
+        assert_eq!(
+            snapshot.network_sends[0].target,
+            snapshot.network_sends[1].target
+        );
     }
 
     #[test]

--- a/crafter/src/wire/backend/raw_socket.rs
+++ b/crafter/src/wire/backend/raw_socket.rs
@@ -145,13 +145,13 @@ const fn network_layer_name(network_layer: NetworkLayer) -> &'static str {
 
 #[cfg(test)]
 mod raw_socket_writer {
-    use std::net::{IpAddr, Ipv4Addr};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     use super::*;
-    use crate::net::{NetError, SendOptions, SendTarget};
+    use crate::net::{NetError, SendMode, SendOptions, SendTarget};
     use crate::{
-        Dot11, Ethernet, Ipv4, LlcSnap, MacAddr, Packet, PacketWire, PacketWireTarget, Radiotap,
-        Raw, Udp,
+        Dot11, Ethernet, Ipv4, Ipv6, LlcSnap, MacAddr, Packet, PacketWire, PacketWireTarget,
+        Radiotap, Raw, Tcp, Udp,
     };
     use crate::{PacketRecord, WireError};
 
@@ -172,6 +172,13 @@ mod raw_socket_writer {
 
     fn radiotap_dot11_packet() -> Packet {
         Radiotap::new() / Dot11::data() / LlcSnap::new() / ipv4_packet()
+    }
+
+    fn ipv6_packet() -> Packet {
+        Ipv6::new()
+            .src(Ipv6Addr::LOCALHOST)
+            .dst(Ipv6Addr::LOCALHOST)
+            / Tcp::new().sport(1234).dport(443)
     }
 
     #[test]
@@ -275,6 +282,79 @@ mod raw_socket_writer {
     }
 
     #[test]
+    fn raw_socket_writer_dry_run_radiotap_link_layer_report_keeps_target_shape() {
+        let packet = radiotap_dot11_packet();
+        let mut writer = RawSocketWriter::new(
+            SendOptions::new()
+                .interface("wifi-dryrun0")
+                .link_layer()
+                .dry_run(),
+        );
+
+        let report = writer.write_record(&PacketRecord::new(packet)).unwrap();
+
+        assert_eq!(report.backend(), &BackendKind::RawSocket);
+        assert!(report.is_dry_run());
+        assert_eq!(
+            report.target_details(),
+            Some("interface=wifi-dryrun0 mode=link-layer target=link-layer:radiotap")
+        );
+    }
+
+    #[test]
+    fn raw_socket_writer_dry_run_rejects_link_mode_for_ipv4_packet() {
+        let mut writer =
+            RawSocketWriter::new(SendOptions::new().interface("eth0").link_layer().dry_run());
+        let error = writer
+            .write_record(&PacketRecord::new(ipv4_packet()))
+            .unwrap_err();
+
+        match error {
+            WireError::Net(NetError::UnsupportedPacketShape {
+                mode,
+                summary: _,
+                reason,
+            }) => {
+                assert_eq!(mode, SendMode::LinkLayer);
+                assert_eq!(
+                    reason,
+                    "link-layer sends require Ethernet, LinuxSll, NullLoopback, or Radiotap / Dot11 Wi-Fi as the first layers"
+                );
+            }
+            other => panic!("expected link-layer shape rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn raw_socket_writer_dry_run_rejects_network_mode_for_ethernet_frame() {
+        let mut writer = RawSocketWriter::new(
+            SendOptions::new()
+                .interface("eth0")
+                .network_layer()
+                .dry_run(),
+        );
+        let error = writer
+            .write_record(&PacketRecord::new(ethernet_packet()))
+            .unwrap_err();
+
+        match error {
+            WireError::Net(NetError::UnsupportedPacketShape {
+                mode,
+                summary,
+                reason,
+            }) => {
+                assert_eq!(mode, SendMode::NetworkLayer);
+                assert!(summary.contains("Ethernet"));
+                assert_eq!(
+                    reason,
+                    "network-layer sends require IPv4 or IPv6 as the first layer"
+                );
+            }
+            other => panic!("expected network-layer shape rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn raw_socket_writer_live_radiotap_routes_to_layer2_via_socket_sender() {
         let mut writer =
             RawSocketWriter::new(SendOptions::new().interface("missing-crafter-wifi0").live());
@@ -318,6 +398,39 @@ mod raw_socket_writer {
                 assert_eq!(protocol, crate::IPPROTO_UDP);
             }
             other => panic!("expected network target, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn raw_socket_writer_dry_run_ipv6_network_layer_stays_plan_only() {
+        let mut writer =
+            RawSocketWriter::new(SendOptions::new().interface("lo").network_layer().dry_run());
+        let report = writer
+            .write_record(&PacketRecord::new(ipv6_packet()))
+            .unwrap();
+
+        assert_eq!(report.backend(), &BackendKind::RawSocket);
+        assert_eq!(report.bytes_requested(), report.bytes_written());
+        assert!(report.is_dry_run());
+        assert_eq!(
+            report.target_details(),
+            Some(
+                "interface=lo mode=network-layer target=network-layer:ipv6 destination=::1 protocol=6"
+            )
+        );
+
+        let plan = writer.plan_packet(&ipv6_packet()).unwrap();
+        match plan.target() {
+            SendTarget::NetworkLayer {
+                network_layer,
+                destination,
+                protocol,
+            } => {
+                assert_eq!(network_layer, NetworkLayer::Ipv6);
+                assert_eq!(destination, IpAddr::V6(Ipv6Addr::LOCALHOST));
+                assert_eq!(protocol, crate::IPPROTO_TCP);
+            }
+            other => panic!("expected IPv6 network target, got {other:?}"),
         }
     }
 }

--- a/crafter/src/wire/backend/raw_socket.rs
+++ b/crafter/src/wire/backend/raw_socket.rs
@@ -264,7 +264,7 @@ mod raw_socket_writer {
         Dot11, Ethernet, Ipv4, Ipv6, LlcSnap, MacAddr, Packet, PacketWire, PacketWireTarget,
         Radiotap, Raw, Tcp, Udp,
     };
-    use crate::{PacketRecord, WireError};
+    use crate::{DuplicateTransform, PacketRecord, Transmitter, WireError};
 
     fn ipv4_packet() -> Packet {
         Ipv4::new()
@@ -555,6 +555,62 @@ mod raw_socket_writer {
             .unwrap();
 
         for report in [&first_report, &second_report] {
+            assert_eq!(report.backend(), &BackendKind::RawSocket);
+            assert_eq!(report.bytes_requested(), expected_len);
+            assert_eq!(report.bytes_written(), expected_len);
+            assert!(!report.is_dry_run());
+            assert_eq!(
+                report.target_details(),
+                Some(
+                    "interface=lo mode=network-layer target=network-layer:ipv4 destination=198.51.100.20 protocol=17"
+                )
+            );
+        }
+
+        let snapshot = backend.snapshot();
+        assert_eq!(snapshot.link_opens.len(), 0);
+        assert_eq!(snapshot.link_sends.len(), 0);
+        assert_eq!(snapshot.network_opens.len(), 1);
+        assert_eq!(
+            snapshot.network_opens[0].socket_protocol,
+            IPPROTO_RAW_SOCKET
+        );
+        assert_eq!(snapshot.network_opens[0].write_buffer_size, expected_len);
+        assert_eq!(snapshot.network_sends.len(), 2);
+        assert_eq!(snapshot.network_sends[0].bytes.len(), expected_len);
+        assert_eq!(snapshot.network_sends[1].bytes.len(), expected_len);
+        assert_eq!(
+            snapshot.network_sends[0].destination,
+            IpAddr::V4(Ipv4Addr::new(198, 51, 100, 20))
+        );
+        assert_eq!(snapshot.network_sends[0].protocol, crate::IPPROTO_UDP);
+        assert_eq!(
+            snapshot.network_sends[0].target,
+            snapshot.network_sends[1].target
+        );
+    }
+
+    #[test]
+    fn transmitter_live_raw_socket_writer_reuses_sender() {
+        let backend = FakePnetBackend::default();
+        let writer = StatefulRawSocketWriter::new_with_backend(
+            SendOptions::new()
+                .interface("lo")
+                .network_layer()
+                .live()
+                .write_buffer_size(8),
+            backend.clone(),
+        );
+        let packet = ipv4_packet();
+        let expected_len = packet.compile().unwrap().len();
+        let mut transmitter = Transmitter::new(writer).with(DuplicateTransform::new());
+
+        let reports = transmitter
+            .send_record(PacketRecord::new(packet.clone()))
+            .unwrap();
+
+        assert_eq!(reports.len(), 2);
+        for report in &reports {
             assert_eq!(report.backend(), &BackendKind::RawSocket);
             assert_eq!(report.bytes_requested(), expected_len);
             assert_eq!(report.bytes_written(), expected_len);

--- a/crafter/src/wire/backend/raw_socket.rs
+++ b/crafter/src/wire/backend/raw_socket.rs
@@ -292,6 +292,18 @@ mod raw_socket_writer {
             / Tcp::new().sport(1234).dport(443)
     }
 
+    fn assert_raw_socket_wire_target(wire: &PacketWire, interface: &str) {
+        assert_eq!(
+            wire.target(),
+            &PacketWireTarget::RawSocketInterface {
+                interface: interface.to_string()
+            }
+        );
+        assert_eq!(wire.target().interface(), Some(interface));
+        assert!(!wire.has_source());
+        assert!(wire.has_writer());
+    }
+
     #[test]
     fn raw_socket_writer_dry_run_maps_socket_send_report() {
         let packet = ipv4_packet();
@@ -319,21 +331,43 @@ mod raw_socket_writer {
     }
 
     #[test]
+    fn raw_socket_writer_packet_wire_live_requires_explicit_mode() {
+        let auto_wire = PacketWire::raw_socket_interface("eth0").open().unwrap();
+        assert_raw_socket_wire_target(&auto_wire, "eth0");
+
+        let mut writer = auto_wire.writer().unwrap();
+        let report = writer
+            .write_record(&PacketRecord::new(ipv4_packet()))
+            .unwrap();
+        assert!(report.is_dry_run());
+        assert!(report.target_details().unwrap().contains("mode=auto"));
+
+        let result = PacketWire::raw_socket_interface("eth0").live().open();
+        let error = match result {
+            Ok(_) => panic!("expected live raw socket auto mode rejection"),
+            Err(error) => error,
+        };
+
+        match error {
+            WireError::Net(NetError::ExplicitSendModeRequired { mode, reason }) => {
+                assert_eq!(mode, SendMode::Auto);
+                assert_eq!(
+                    reason,
+                    "live raw socket packet wires require explicit link_layer() or network_layer() mode"
+                );
+            }
+            other => panic!("expected explicit send mode error, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn raw_socket_writer_packet_wire_builder_is_write_only_and_preserves_mode() {
         let wire = PacketWire::raw_socket_interface("eth0")
             .network_layer()
             .open()
             .unwrap();
 
-        assert_eq!(
-            wire.target(),
-            &PacketWireTarget::RawSocketInterface {
-                interface: "eth0".to_string()
-            }
-        );
-        assert_eq!(wire.target().interface(), Some("eth0"));
-        assert!(!wire.has_source());
-        assert!(wire.has_writer());
+        assert_raw_socket_wire_target(&wire, "eth0");
 
         let mut writer = wire.writer().unwrap();
         let report = writer
@@ -346,6 +380,20 @@ mod raw_socket_writer {
             .target_details()
             .unwrap()
             .contains("mode=network-layer"));
+
+        let live_network = PacketWire::raw_socket_interface("net-live0")
+            .network_layer()
+            .live()
+            .open()
+            .unwrap();
+        assert_raw_socket_wire_target(&live_network, "net-live0");
+
+        let live_link = PacketWire::raw_socket_interface("link-live0")
+            .link_layer()
+            .live()
+            .open()
+            .unwrap();
+        assert_raw_socket_wire_target(&live_link, "link-live0");
     }
 
     #[test]

--- a/crafter/src/wire/packet_wire.rs
+++ b/crafter/src/wire/packet_wire.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crate::net::send::validated_interface;
-use crate::net::{SendMode, SendOptions};
+use crate::net::{NetError, SendMode, SendOptions};
 use crate::wire::backend::pcap::PcapLinkType;
 use crate::wire::backend::whad::{WhadBleMode, WhadDot15d4Mode};
 
@@ -575,6 +575,15 @@ impl RawSocketWireBuilder {
     /// Open this write-only raw socket target as one packet wire.
     pub fn open(self) -> Result<PacketWire> {
         let interface = validated_interface(&self.options)?;
+        if !self.options.is_dry_run() && self.options.send_mode() == SendMode::Auto {
+            return Err(NetError::ExplicitSendModeRequired {
+                mode: self.options.send_mode(),
+                reason:
+                    "live raw socket packet wires require explicit link_layer() or network_layer() mode",
+            }
+            .into());
+        }
+
         let writer = RawSocketWriter::new(self.options);
 
         Ok(PacketWire {

--- a/crafter/tests/public_api.rs
+++ b/crafter/tests/public_api.rs
@@ -45,6 +45,51 @@ fn sctp_protocol_display_labels_ipv4_and_ipv6_summary_and_show() {
 }
 
 #[test]
+fn packet_sender_public_api() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let packet = Ipv4::new()
+        .src(Ipv4Addr::new(192, 0, 2, 10))
+        .dst(Ipv4Addr::new(198, 51, 100, 20))
+        / Udp::new().sport(49152).dport(53)
+        / Raw::from("query");
+    let _root_sender = crafter::PacketSender::open(
+        SendOptions::new()
+            .iface("root-dry-run0")
+            .network_layer()
+            .dry_run(),
+    )?;
+    let _net_sender = crafter::net::PacketSender::open(
+        SendOptions::new()
+            .iface("net-dry-run0")
+            .network_layer()
+            .dry_run(),
+    )?;
+    let mut sender = PacketSender::open(
+        SendOptions::new()
+            .iface("prelude-dry-run0")
+            .network_layer()
+            .dry_run(),
+    )?;
+
+    let report = sender.send(&packet)?;
+
+    assert!(report.is_dry_run());
+    assert_eq!(report.bytes_sent(), report.plan().len());
+    assert_eq!(report.plan().interface(), "prelude-dry-run0");
+    assert_eq!(report.plan().requested_mode(), SendMode::NetworkLayer);
+    assert_eq!(report.plan().bytes(), packet.compile()?.as_bytes());
+    assert_eq!(
+        report.plan().target(),
+        SendTarget::NetworkLayer {
+            network_layer: NetworkLayer::Ipv4,
+            destination: Ipv4Addr::new(198, 51, 100, 20).into(),
+            protocol: IPPROTO_UDP
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
 fn ble_prelude_reexports_compile() {
     use crafter::prelude::{AdStructure, BleLlAdv, BleRadio};
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -376,6 +376,41 @@ stack delivery are out of scope for the crate primitive.
 
 ## Send And Send-Receive
 
+The net API has both one-shot and reusable send surfaces:
+
+| API | Role |
+| --- | --- |
+| `send_packet` and `SocketSender` | Compatibility one-shot sends and dry-run plans for callers that send one packet at a time. |
+| `PacketSender` | Reusable sender that keeps one live backend open for an explicit homogeneous send class. |
+| `PacketWire::raw_socket_interface` | Packet-wire writer surface for `Transmitter`; live writers reuse `PacketSender` internally. |
+
+`PacketSender` is useful when a generated tool sends several packets through
+the same interface. Dry-run mode only compiles and plans packets:
+
+```rust
+let packet =
+    Ipv4::new().src("192.0.2.10")?.dst("198.51.100.20")?
+    / Udp::new().sport(40000).dport(33434)
+    / Raw::from("dry-run payload");
+
+let mut sender = PacketSender::open(
+    SendOptions::new()
+        .iface("eth0")
+        .network_layer()
+        .dry_run(),
+)?;
+
+let report = sender.send(&packet)?;
+assert!(report.is_dry_run());
+```
+
+Live reusable senders must use `.live()` with an explicit `.link_layer()` or
+`.network_layer()` mode. Link-layer live senders handle Ethernet and radiotap
+frames; network-layer live senders currently handle bare IPv4 packets.
+Full-header IPv6 network-layer live sends remain unsupported. A `PacketSender`
+is homogeneous, so tools that need both Ethernet/radiotap frames and bare IPv4
+packets should open separate senders.
+
 ```rust
 let report = packet.send_recv_report(
     SendRecv::new()
@@ -405,7 +440,11 @@ let report = send_recv_packets(
 ```
 
 Raw socket operations are exposed through typed wrappers rather than integer
-file descriptors in normal examples.
+file descriptors in normal examples. Use
+`PacketWire::raw_socket_interface("eth0").link_layer().live()` for live
+Ethernet or radiotap writer streams, and
+`PacketWire::raw_socket_interface("eth0").network_layer().live()` for live
+bare IPv4 writer streams.
 
 ## UDP Options
 
@@ -899,7 +938,7 @@ in the [ICMPv6 guide](../guide/icmpv6.md).
 | `decode_bytes` | Decode from link, network, and IPv4 entry points while preserving raw payloads. |
 | `custom_registry` | Protocol registry customization and default decode comparison. |
 | `send_plan` | Network-layer send planning, compiled bytes, targets, and derived reply filters. |
-| `send_packet` | Network-layer and link-layer send reports using dry-run options by default. |
+| `send_packet` | Network-layer and link-layer send reports using dry-run options by default; use `PacketSender` for repeated live sends through one explicit send class. |
 | `send_recv_icmp` | ICMP send/receive configuration, retry timing, filters, and dry-run reports. |
 | `network_ping` | Network-layer ICMP echo send/receive for disposable endpoint smoke tests. |
 | `reply_matching` | Synthetic request/reply matching and generated reply filters. |

--- a/docs/reference/wire.md
+++ b/docs/reference/wire.md
@@ -398,7 +398,8 @@ the same interface target and is prepared to handle a typed capability error.
 
 For raw socket sends through the wire API, use the dedicated raw socket
 constructor. It defaults to dry-run planning; `.live()` is the explicit opt-in
-for live raw socket transmission.
+for live raw socket transmission, and live opens require an explicit
+`.link_layer()` or `.network_layer()` send class.
 
 ```rust
 use crafter::prelude::*;
@@ -418,8 +419,11 @@ assert!(reports.iter().all(|report| report.is_dry_run()));
 # Ok::<(), crafter::CrafterError>(())
 ```
 
-Live send requires `.live()` and the normal raw socket privileges for the
-selected platform:
+Dry-run raw socket writers still plan IPv4, IPv6, Ethernet, and radiotap
+records without opening a live backend.
+
+Live send requires `.live()`, an explicit send class, and the normal raw socket
+privileges for the selected platform:
 
 ```rust
 use crafter::prelude::*;
@@ -439,9 +443,13 @@ let _reports = tx.send(
 # Ok::<(), crafter::CrafterError>(())
 ```
 
-Unsupported radiotap Wi-Fi injection is not silently rerouted through this raw
-socket path. Monitor-mode Dot11 injection needs a backend that explicitly
-supports that medium.
+A live raw socket writer owns one reusable `PacketSender`, so repeated
+`Transmitter` writes reuse the opened backend for one homogeneous send class.
+Use `.link_layer()` for Ethernet and radiotap frames. Use `.network_layer()` for
+bare IPv4 packets; full-header IPv6 network-layer live sends remain unsupported.
+If a tool needs both Ethernet/radiotap frames and bare IPv4 packets, open
+separate writers or senders. A writer opened for one class fails with a typed
+error when given the other class instead of switching backends silently.
 
 ## Parallel Interfaces
 

--- a/tools/oracle/adapters/src/bin/live_endpoint.rs
+++ b/tools/oracle/adapters/src/bin/live_endpoint.rs
@@ -309,14 +309,31 @@ fn run_sender(
     } else {
         send_options.live()
     };
-    let sender = SocketSender::new(send_options);
+    let mut packet_sender = match send_mode {
+        SendMode::LinkLayer | SendMode::NetworkLayer if !packets.is_empty() => {
+            Some(PacketSender::open(send_options.clone())?)
+        }
+        _ => None,
+    };
+    let socket_sender = if packet_sender.is_none() {
+        Some(SocketSender::new(send_options))
+    } else {
+        None
+    };
 
     let mut statuses = Vec::with_capacity(prepared.len());
     let mut send_reports = Vec::with_capacity(prepared.len());
     let mut live_sent_count = 0usize;
 
     for (offset, prepared_packet) in prepared.iter().enumerate() {
-        let report = sender.send(&packets[offset])?;
+        let report = if let Some(sender) = packet_sender.as_mut() {
+            sender.send(&packets[offset])?
+        } else {
+            socket_sender
+                .as_ref()
+                .expect("one-shot sender is available when packet sender is not used")
+                .send(&packets[offset])?
+        };
         if !mode.is_dry_run() {
             std::thread::sleep(LIVE_SEND_INTERVAL);
         }
@@ -2694,6 +2711,144 @@ mod live_capture_polling {
 
         assert_eq!(captured.len(), 1);
         assert!(source.emitted);
+    }
+}
+
+#[cfg(test)]
+mod live_endpoint_sender_modes {
+    use super::*;
+    use serde_json::json;
+
+    fn ipv4_packet(index: usize, root: &str) -> PreparedPacket {
+        let packet = Ipv4::new()
+            .src_str("192.0.2.10")
+            .expect("valid source")
+            .dst_str("198.51.100.20")
+            .expect("valid destination")
+            .id(index as u16)
+            .ttl(64)
+            .ipv4_protocol(Ipv4Protocol::Udp)
+            / Udp::new().sport(49152 + index as u16).dport(9)
+            / Raw::from_bytes(b"oracle-live-endpoint");
+        let raw_hex = hex_bytes(packet.compile().expect("packet compiles").as_bytes());
+        PreparedPacket {
+            index,
+            packet,
+            root: root.to_string(),
+            raw_hex,
+            feature_tags: Vec::new(),
+        }
+    }
+
+    fn ethernet_packet(index: usize) -> PreparedPacket {
+        let inner = ipv4_packet(index, "l3:ipv4").packet;
+        let packet = Packet::from_layer(
+            Ethernet::new()
+                .src(MacAddr::from([0x00, 0x00, 0x5e, 0x00, 0x53, 0x10]))
+                .dst(MacAddr::from([0x00, 0x00, 0x5e, 0x00, 0x53, 0x20]))
+                .ethertype(ETHERTYPE_IPV4),
+        )
+        .concat(inner);
+        let raw_hex = hex_bytes(packet.compile().expect("packet compiles").as_bytes());
+        PreparedPacket {
+            index,
+            packet,
+            root: "link:ethernet".to_string(),
+            raw_hex,
+            feature_tags: Vec::new(),
+        }
+    }
+
+    fn sender_request(local_addresses: Value, peer_addresses: Value) -> EndpointRequest {
+        EndpointRequest {
+            provider: "local-dry-run".to_string(),
+            backend: BACKEND_NAME.to_string(),
+            seed: 17,
+            profile: "smoke".to_string(),
+            packet_plans: Vec::new(),
+            direction: "libcrafter_to_backend".to_string(),
+            endpoint_id: "local-dry-run-libcrafter".to_string(),
+            endpoint_role: "libcrafter".to_string(),
+            peer_role: "reference_backend".to_string(),
+            local_addresses,
+            peer_addresses,
+            interface: "dry-run0".to_string(),
+            timeout_seconds: 1,
+            artifact_paths: json!({}),
+            metadata: json!({ "phase_role": "sender" }),
+        }
+    }
+
+    #[test]
+    fn live_endpoint_common_send_mode_rejects_mixed_roots() {
+        let prepared = vec![ipv4_packet(1, "l3:ipv4"), ethernet_packet(2)];
+
+        let error = common_send_mode(&prepared)
+            .expect_err("mixed network and link roots must be rejected")
+            .to_string();
+
+        assert!(
+            error.contains("mixed link-layer and network-layer"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn live_endpoint_ethernet_wrapping_forces_link_layer_mode() {
+        let request = sender_request(
+            json!({ "mac": "00:00:5e:00:53:01" }),
+            json!({ "mac": "00:00:5e:00:53:02" }),
+        );
+        let prepared = vec![ipv4_packet(1, "l3:ipv4"), ethernet_packet(2)];
+
+        let response =
+            run_sender(&request, RunMode::DryRun, &prepared).expect("sender dry-run succeeds");
+
+        assert_eq!(
+            response.pointer("/metadata/detail/send_mode"),
+            Some(&json!("LinkLayer"))
+        );
+        let statuses = response
+            .get("per_index_status")
+            .and_then(Value::as_array)
+            .expect("statuses");
+        assert_eq!(statuses.len(), 2);
+        for status in statuses {
+            assert_eq!(status.get("send_mode"), Some(&json!("link-layer")));
+            assert_eq!(status.get("send_root"), Some(&json!("link:ethernet")));
+        }
+    }
+
+    #[test]
+    fn live_endpoint_sender_reports_explicit_network_mode() {
+        let request = sender_request(json!({}), json!({}));
+        let prepared = vec![ipv4_packet(1, "l3:ipv4"), ipv4_packet(2, "l3:ipv4")];
+
+        let response =
+            run_sender(&request, RunMode::DryRun, &prepared).expect("sender dry-run succeeds");
+
+        assert_eq!(
+            response.pointer("/metadata/detail/send_mode"),
+            Some(&json!("NetworkLayer"))
+        );
+        let reports = response
+            .pointer("/metadata/detail/send_reports")
+            .and_then(Value::as_array)
+            .expect("send reports");
+        assert_eq!(reports.len(), 2);
+        for report in reports {
+            let attempt = report
+                .get("reports")
+                .and_then(Value::as_array)
+                .and_then(|attempts| attempts.first())
+                .expect("one send report attempt");
+            assert_eq!(attempt.get("send_mode"), Some(&json!("NetworkLayer")));
+            assert_eq!(
+                attempt.get("send_mode_label"),
+                Some(&json!("network-layer"))
+            );
+            assert_eq!(attempt.get("dry_run"), Some(&json!(true)));
+        }
     }
 }
 

--- a/tools/probe/adapters/src/arp.rs
+++ b/tools/probe/adapters/src/arp.rs
@@ -23,8 +23,8 @@ use crate::common::{
     capture_filter, captured_data, decoded_packet_json, failed_outcome, hex_bytes,
     observed_response, open_capture_sniffer, plan_json, required_str, required_u16,
     send_report_json, target_service_json, ArpSend, ArpValidation, CandidateValidation,
-    ExampleResult, ProbeOutcome, ProbePlan, StimulusEndpointRequest, FAILURE_DECODE_FAILED,
-    FAILURE_TIMEOUT, FAILURE_WRONG_PAYLOAD, FAILURE_WRONG_PEER,
+    ExampleResult, ProbeOutcome, ProbePacketSender, ProbePlan, StimulusEndpointRequest,
+    FAILURE_DECODE_FAILED, FAILURE_TIMEOUT, FAILURE_WRONG_PAYLOAD, FAILURE_WRONG_PEER,
 };
 
 /// Stable identifier for the ARP case module.
@@ -111,6 +111,23 @@ pub fn run_arp_live(
     if let Some(sends) = plan.arp_sends.as_deref() {
         return run_arp_multi_send_live(request, plan, sends);
     }
+    let mut sender = SocketSender::new(
+        SendOptions::new()
+            .iface(request.interface.clone())
+            .link_layer()
+            .live(),
+    );
+    run_arp_live_with_sender(request, plan, &mut sender)
+}
+
+fn run_arp_live_with_sender<S>(
+    request: &StimulusEndpointRequest,
+    plan: &ProbePlan,
+    sender: &mut S,
+) -> ExampleResult<ProbeOutcome>
+where
+    S: ProbePacketSender,
+{
     let packet = arp_who_has_packet(plan)?;
     let timeout = Duration::from_secs(request.timeout_seconds.max(1));
     let mut sniffer =
@@ -127,14 +144,7 @@ pub fn run_arp_live(
                 ));
             }
         };
-    let send_report = match SocketSender::new(
-        SendOptions::new()
-            .iface(request.interface.clone())
-            .link_layer()
-            .live(),
-    )
-    .send(&packet)
-    {
+    let send_report = match sender.send_probe_packet(&packet) {
         Ok(report) => report,
         Err(err) => {
             return Ok(failed_outcome(
@@ -398,10 +408,28 @@ fn run_arp_multi_send_live(
     let mut any_received = false;
     let mut failure_reason: Option<&'static str> = None;
     let mut errors: Vec<String> = Vec::new();
+    let mut sender = match PacketSender::open(
+        SendOptions::new()
+            .iface(request.interface.clone())
+            .link_layer()
+            .live(),
+    ) {
+        Ok(sender) => sender,
+        Err(err) => {
+            return Ok(failed_outcome(
+                plan,
+                FAILURE_DECODE_FAILED,
+                vec![format!("send failed: {err}")],
+                None,
+                false,
+                false,
+            ));
+        }
+    };
 
     for (offset, send) in sends.iter().enumerate() {
         let send_plan = send_as_plan(plan, send);
-        let outcome = run_arp_live(request, &send_plan)?;
+        let outcome = run_arp_live_with_sender(request, &send_plan, &mut sender)?;
         any_sent |= outcome.sent;
         any_received |= outcome.received;
         let status = outcome
@@ -1119,6 +1147,39 @@ mod tests {
         let arp = packet.layer::<Arp>().expect("arp layer");
         assert_eq!(arp.opcode_value(), u16::from(ArpOperation::Request));
         assert_eq!(arp.target_ipv4().unwrap().to_string(), "10.64.0.20");
+    }
+
+    #[test]
+    fn multi_send_packet_sender_preserves_link_send_report_fields() {
+        let parent = repeat_plan();
+        let sends = parent.arp_sends.clone().unwrap();
+        let mut sender = PacketSender::open(
+            SendOptions::new()
+                .iface("dry-run0")
+                .link_layer()
+                .dry_run(),
+        )
+        .unwrap();
+
+        for send in &sends {
+            let send_plan = send_as_plan(&parent, send);
+            let packet = arp_who_has_packet(&send_plan).unwrap();
+            let report = sender.send_probe_packet(&packet).unwrap();
+            let report_json = send_report_json(&report);
+
+            assert!(report.is_dry_run());
+            assert_eq!(report.plan().requested_mode(), SendMode::LinkLayer);
+            assert!(matches!(
+                report.plan().target(),
+                SendTarget::LinkLayer {
+                    link_type: LinkType::Ethernet
+                }
+            ));
+            assert_eq!(report_json["dry_run"], serde_json::json!(true));
+            assert!(report_json["target"]
+                .as_str()
+                .is_some_and(|target| target.contains("LinkLayer")));
+        }
     }
 
     /// Build an `arp-alias-address-reply` plan: the who-has resolves a *secondary*

--- a/tools/probe/adapters/src/arp.rs
+++ b/tools/probe/adapters/src/arp.rs
@@ -1153,13 +1153,9 @@ mod tests {
     fn multi_send_packet_sender_preserves_link_send_report_fields() {
         let parent = repeat_plan();
         let sends = parent.arp_sends.clone().unwrap();
-        let mut sender = PacketSender::open(
-            SendOptions::new()
-                .iface("dry-run0")
-                .link_layer()
-                .dry_run(),
-        )
-        .unwrap();
+        let mut sender =
+            PacketSender::open(SendOptions::new().iface("dry-run0").link_layer().dry_run())
+                .unwrap();
 
         for send in &sends {
             let send_plan = send_as_plan(&parent, send);

--- a/tools/probe/adapters/src/common.rs
+++ b/tools/probe/adapters/src/common.rs
@@ -50,6 +50,22 @@ pub fn captured_data(record: &PacketRecord) -> &[u8] {
     record.metadata().captured_bytes().unwrap_or(&[])
 }
 
+pub trait ProbePacketSender {
+    fn send_probe_packet(&mut self, packet: &Packet) -> crafter::net::Result<SendReport>;
+}
+
+impl ProbePacketSender for PacketSender {
+    fn send_probe_packet(&mut self, packet: &Packet) -> crafter::net::Result<SendReport> {
+        self.send(packet)
+    }
+}
+
+impl ProbePacketSender for SocketSender {
+    fn send_probe_packet(&mut self, packet: &Packet) -> crafter::net::Result<SendReport> {
+        self.send(packet)
+    }
+}
+
 #[derive(Debug)]
 pub struct Args {
     pub input: Option<PathBuf>,

--- a/tools/probe/adapters/src/dhcpv4.rs
+++ b/tools/probe/adapters/src/dhcpv4.rs
@@ -19,8 +19,8 @@ use crate::common::{
     capture_filter, captured_data, decode_hex, decoded_packet_json, failed_outcome, hex_bytes,
     observed_response, open_capture_sniffer, plan_json, required_str, required_u32,
     required_u8_list, send_report_json, target_service_json, CandidateValidation, Dhcpv4Send,
-    ExampleResult, ProbeOutcome, ProbePlan, StimulusEndpointRequest, FAILURE_DECODE_FAILED,
-    FAILURE_TIMEOUT, FAILURE_WRONG_PAYLOAD, FAILURE_WRONG_PEER,
+    ExampleResult, ProbeOutcome, ProbePacketSender, ProbePlan, StimulusEndpointRequest,
+    FAILURE_DECODE_FAILED, FAILURE_TIMEOUT, FAILURE_WRONG_PAYLOAD, FAILURE_WRONG_PEER,
 };
 
 /// Stable identifier for the DHCPv4 case module.
@@ -86,6 +86,23 @@ pub fn run_dhcpv4_live(
     if let Some(sends) = plan.dhcpv4_sends.as_deref() {
         return run_dhcpv4_multi_send_live(request, plan, sends);
     }
+    let mut sender = SocketSender::new(
+        SendOptions::new()
+            .iface(request.interface.clone())
+            .network_layer()
+            .live(),
+    );
+    run_dhcpv4_live_with_sender(request, plan, &mut sender)
+}
+
+fn run_dhcpv4_live_with_sender<S>(
+    request: &StimulusEndpointRequest,
+    plan: &ProbePlan,
+    sender: &mut S,
+) -> ExampleResult<ProbeOutcome>
+where
+    S: ProbePacketSender,
+{
     let packet = dhcpv4_packet(plan)?;
     let timeout = Duration::from_secs(request.timeout_seconds.max(1));
     let mut sniffer =
@@ -102,14 +119,7 @@ pub fn run_dhcpv4_live(
                 ));
             }
         };
-    let send_report = match SocketSender::new(
-        SendOptions::new()
-            .iface(request.interface.clone())
-            .network_layer()
-            .live(),
-    )
-    .send(&packet)
-    {
+    let send_report = match sender.send_probe_packet(&packet) {
         Ok(report) => report,
         Err(err) => {
             return Ok(failed_outcome(
@@ -384,10 +394,28 @@ fn run_dhcpv4_multi_send_live(
     let mut any_received = false;
     let mut failure_reason: Option<&'static str> = None;
     let mut errors: Vec<String> = Vec::new();
+    let mut sender = match PacketSender::open(
+        SendOptions::new()
+            .iface(request.interface.clone())
+            .network_layer()
+            .live(),
+    ) {
+        Ok(sender) => sender,
+        Err(err) => {
+            return Ok(failed_outcome(
+                plan,
+                FAILURE_DECODE_FAILED,
+                vec![format!("send failed: {err}")],
+                None,
+                false,
+                false,
+            ));
+        }
+    };
 
     for (offset, send) in sends.iter().enumerate() {
         let send_plan = send_as_plan(plan, send);
-        let outcome = run_dhcpv4_live(request, &send_plan)?;
+        let outcome = run_dhcpv4_live_with_sender(request, &send_plan, &mut sender)?;
         any_sent |= outcome.sent;
         any_received |= outcome.received;
         let status = outcome
@@ -2749,6 +2777,40 @@ mod tests {
                 .map(Dhcpv4MessageType::code),
             Some(1)
         );
+    }
+
+    #[test]
+    fn multi_send_packet_sender_preserves_network_send_report_fields() {
+        let plan = rapid_repeat_plan();
+        let sends = plan.dhcpv4_sends.clone().unwrap();
+        let mut sender = PacketSender::open(
+            SendOptions::new()
+                .iface("dry-run0")
+                .network_layer()
+                .dry_run(),
+        )
+        .unwrap();
+
+        for send in &sends {
+            let send_plan = send_as_plan(&plan, send);
+            let packet = dhcpv4_packet(&send_plan).unwrap();
+            let report = sender.send_probe_packet(&packet).unwrap();
+            let report_json = send_report_json(&report);
+
+            assert!(report.is_dry_run());
+            assert_eq!(report.plan().requested_mode(), SendMode::NetworkLayer);
+            assert!(matches!(
+                report.plan().target(),
+                SendTarget::NetworkLayer {
+                    network_layer: NetworkLayer::Ipv4,
+                    ..
+                }
+            ));
+            assert_eq!(report_json["dry_run"], serde_json::json!(true));
+            assert!(report_json["target"]
+                .as_str()
+                .is_some_and(|target| target.contains("NetworkLayer")));
+        }
     }
 
     #[test]

--- a/tools/probe/adapters/src/dns.rs
+++ b/tools/probe/adapters/src/dns.rs
@@ -11,8 +11,8 @@ use crate::common::{
     capture_filter, captured_data, decode_hex, decoded_packet_json, failed_outcome, hex_bytes,
     observed_response, open_capture_sniffer, plan_json, required_str, required_u16,
     send_report_json, target_service_json, CandidateValidation, DnsSend, EdnsOptionExpectation,
-    ExampleResult, ProbeOutcome, ProbePlan, StimulusEndpointRequest, FAILURE_DECODE_FAILED,
-    FAILURE_TIMEOUT, FAILURE_WRONG_PAYLOAD, FAILURE_WRONG_PEER,
+    ExampleResult, ProbeOutcome, ProbePacketSender, ProbePlan, StimulusEndpointRequest,
+    FAILURE_DECODE_FAILED, FAILURE_TIMEOUT, FAILURE_WRONG_PAYLOAD, FAILURE_WRONG_PEER,
 };
 
 pub fn run_dns_dry_run(
@@ -75,6 +75,23 @@ pub fn run_dns_live(
     if let Some(sends) = plan.sends.as_deref() {
         return run_dns_multi_send_live(request, plan, sends);
     }
+    let mut sender = SocketSender::new(
+        SendOptions::new()
+            .iface(request.interface.clone())
+            .network_layer()
+            .live(),
+    );
+    run_dns_live_with_sender(request, plan, &mut sender)
+}
+
+fn run_dns_live_with_sender<S>(
+    request: &StimulusEndpointRequest,
+    plan: &ProbePlan,
+    sender: &mut S,
+) -> ExampleResult<ProbeOutcome>
+where
+    S: ProbePacketSender,
+{
     let packet = dns_packet(plan)?;
     let timeout = Duration::from_secs(request.timeout_seconds.max(1));
     let mut sniffer =
@@ -91,14 +108,7 @@ pub fn run_dns_live(
                 ));
             }
         };
-    let send_report = match SocketSender::new(
-        SendOptions::new()
-            .iface(request.interface.clone())
-            .network_layer()
-            .live(),
-    )
-    .send(&packet)
-    {
+    let send_report = match sender.send_probe_packet(&packet) {
         Ok(report) => report,
         Err(err) => {
             return Ok(failed_outcome(
@@ -377,10 +387,28 @@ fn run_dns_multi_send_live(
     let mut any_received = false;
     let mut failure_reason: Option<&'static str> = None;
     let mut errors: Vec<String> = Vec::new();
+    let mut sender = match PacketSender::open(
+        SendOptions::new()
+            .iface(request.interface.clone())
+            .network_layer()
+            .live(),
+    ) {
+        Ok(sender) => sender,
+        Err(err) => {
+            return Ok(failed_outcome(
+                plan,
+                FAILURE_DECODE_FAILED,
+                vec![format!("send failed: {err}")],
+                None,
+                false,
+                false,
+            ));
+        }
+    };
 
     for (offset, send) in sends.iter().enumerate() {
         let send_plan = send_as_plan(plan, send);
-        let outcome = run_dns_live(request, &send_plan)?;
+        let outcome = run_dns_live_with_sender(request, &send_plan, &mut sender)?;
         any_sent |= outcome.sent;
         any_received |= outcome.received;
         let status = outcome
@@ -2500,5 +2528,39 @@ mod tests {
             expected_responses[0]["answer"]["data"], expected_responses[1]["answer"]["data"],
             "each expected response carries its own answer"
         );
+    }
+
+    #[test]
+    fn multi_send_packet_sender_preserves_send_report_fields() {
+        let plan = repeat_transaction_plan();
+        let sends = plan.sends.clone().unwrap();
+        let mut sender = PacketSender::open(
+            SendOptions::new()
+                .iface("dry-run0")
+                .network_layer()
+                .dry_run(),
+        )
+        .unwrap();
+
+        for send in &sends {
+            let send_plan = send_as_plan(&plan, send);
+            let packet = dns_packet(&send_plan).unwrap();
+            let report = sender.send_probe_packet(&packet).unwrap();
+            let report_json = send_report_json(&report);
+
+            assert!(report.is_dry_run());
+            assert_eq!(report.plan().requested_mode(), SendMode::NetworkLayer);
+            assert!(matches!(
+                report.plan().target(),
+                SendTarget::NetworkLayer {
+                    network_layer: NetworkLayer::Ipv4,
+                    ..
+                }
+            ));
+            assert_eq!(report_json["dry_run"], serde_json::json!(true));
+            assert!(report_json["target"]
+                .as_str()
+                .is_some_and(|target| target.contains("NetworkLayer")));
+        }
     }
 }

--- a/tools/probe/adapters/src/udp.rs
+++ b/tools/probe/adapters/src/udp.rs
@@ -22,8 +22,8 @@ use crate::common::{
     capture_filter, captured_data, decode_hex, decoded_packet_json, failed_outcome, hex_bytes,
     observed_response, open_capture_sniffer, plan_json, raw_payload, required_str, required_u16,
     send_report_json, target_service_json, CandidateValidation, ExampleResult, ProbeOutcome,
-    ProbePlan, StimulusEndpointRequest, UdpSend, FAILURE_DECODE_FAILED, FAILURE_TIMEOUT,
-    FAILURE_WRONG_PAYLOAD, FAILURE_WRONG_PEER,
+    ProbePacketSender, ProbePlan, StimulusEndpointRequest, UdpSend, FAILURE_DECODE_FAILED,
+    FAILURE_TIMEOUT, FAILURE_WRONG_PAYLOAD, FAILURE_WRONG_PEER,
 };
 use crate::icmp;
 
@@ -107,6 +107,23 @@ pub fn run_udp_live(
     if let Some(sends) = plan.udp_sends.as_deref() {
         return run_udp_multi_send_live(request, plan, sends);
     }
+    let mut sender = SocketSender::new(
+        SendOptions::new()
+            .iface(request.interface.clone())
+            .network_layer()
+            .live(),
+    );
+    run_udp_live_with_sender(request, plan, &mut sender)
+}
+
+fn run_udp_live_with_sender<S>(
+    request: &StimulusEndpointRequest,
+    plan: &ProbePlan,
+    sender: &mut S,
+) -> ExampleResult<ProbeOutcome>
+where
+    S: ProbePacketSender,
+{
     let packet = udp_packet(plan)?;
     let timeout = Duration::from_secs(request.timeout_seconds.max(1));
     let mut sniffer =
@@ -123,14 +140,7 @@ pub fn run_udp_live(
                 ));
             }
         };
-    let send_report = match SocketSender::new(
-        SendOptions::new()
-            .iface(request.interface.clone())
-            .network_layer()
-            .live(),
-    )
-    .send(&packet)
-    {
+    let send_report = match sender.send_probe_packet(&packet) {
         Ok(report) => report,
         Err(err) => {
             return Ok(failed_outcome(
@@ -609,10 +619,28 @@ fn run_udp_multi_send_live(
     let mut any_received = false;
     let mut failure_reason: Option<&'static str> = None;
     let mut errors: Vec<String> = Vec::new();
+    let mut sender = match PacketSender::open(
+        SendOptions::new()
+            .iface(request.interface.clone())
+            .network_layer()
+            .live(),
+    ) {
+        Ok(sender) => sender,
+        Err(err) => {
+            return Ok(failed_outcome(
+                plan,
+                FAILURE_DECODE_FAILED,
+                vec![format!("send failed: {err}")],
+                None,
+                false,
+                false,
+            ));
+        }
+    };
 
     for (offset, send) in sends.iter().enumerate() {
         let send_plan = send_as_plan(plan, send);
-        let outcome = run_udp_live(request, &send_plan)?;
+        let outcome = run_udp_live_with_sender(request, &send_plan, &mut sender)?;
         any_sent |= outcome.sent;
         any_received |= outcome.received;
         let status = outcome
@@ -1225,6 +1253,89 @@ mod tests {
         plan.expected_udp_checksum_statuses =
             Some(vec!["valid".to_string(), "ipv4_no_checksum".to_string()]);
         plan
+    }
+
+    fn multi_shot_plan() -> ProbePlan {
+        let first = b"udp-multi:first";
+        let second = b"udp-multi:second";
+        let sends = vec![
+            UdpSend {
+                index: Some(0),
+                sequence_marker: Some("first".to_string()),
+                source_ipv4: Some("192.0.2.10".to_string()),
+                destination_ipv4: Some("192.0.2.20".to_string()),
+                expected_reply_source_ipv4: Some("192.0.2.20".to_string()),
+                expected_reply_destination_ipv4: Some("192.0.2.10".to_string()),
+                source_port: Some(46000),
+                destination_port: Some(30000),
+                payload_hex: Some(hex_bytes(first)),
+                payload_length: Some(first.len()),
+                expected_payload_hex: Some(hex_bytes(first)),
+                expected_payload_length: Some(first.len()),
+                expected_udp_length: Some((8 + first.len()) as u16),
+                expected_udp_checksum_present: Some(true),
+                expected_udp_checksum_statuses: Some(vec!["valid".to_string()]),
+                capture_filter: None,
+                validation: None,
+            },
+            UdpSend {
+                index: Some(1),
+                sequence_marker: Some("second".to_string()),
+                source_ipv4: Some("192.0.2.10".to_string()),
+                destination_ipv4: Some("192.0.2.20".to_string()),
+                expected_reply_source_ipv4: Some("192.0.2.20".to_string()),
+                expected_reply_destination_ipv4: Some("192.0.2.10".to_string()),
+                source_port: Some(46001),
+                destination_port: Some(30000),
+                payload_hex: Some(hex_bytes(second)),
+                payload_length: Some(second.len()),
+                expected_payload_hex: Some(hex_bytes(second)),
+                expected_payload_length: Some(second.len()),
+                expected_udp_length: Some((8 + second.len()) as u16),
+                expected_udp_checksum_present: Some(true),
+                expected_udp_checksum_statuses: Some(vec!["valid".to_string()]),
+                capture_filter: None,
+                validation: None,
+            },
+        ];
+        let mut plan = echo_plan("udp-multi-shot-order", first);
+        plan.send_count = Some(sends.len());
+        plan.udp_sends = Some(sends);
+        plan
+    }
+
+    #[test]
+    fn multi_send_packet_sender_preserves_send_report_fields() {
+        let plan = multi_shot_plan();
+        let sends = plan.udp_sends.clone().unwrap();
+        let mut sender = PacketSender::open(
+            SendOptions::new()
+                .iface("dry-run0")
+                .network_layer()
+                .dry_run(),
+        )
+        .unwrap();
+
+        for send in &sends {
+            let send_plan = send_as_plan(&plan, send);
+            let packet = udp_packet(&send_plan).unwrap();
+            let report = sender.send_probe_packet(&packet).unwrap();
+            let report_json = send_report_json(&report);
+
+            assert!(report.is_dry_run());
+            assert_eq!(report.plan().requested_mode(), SendMode::NetworkLayer);
+            assert!(matches!(
+                report.plan().target(),
+                SendTarget::NetworkLayer {
+                    network_layer: NetworkLayer::Ipv4,
+                    ..
+                }
+            ));
+            assert_eq!(report_json["dry_run"], serde_json::json!(true));
+            assert!(report_json["target"]
+                .as_str()
+                .is_some_and(|target| target.contains("NetworkLayer")));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a reusable stateful packet sender API for dry-run, network-layer, and link-layer packet sends.
- Reuse the sender across one-shot send, send/receive, batch send, live endpoint, oracle, and probe paths.
- Document the public API and keep live raw socket use behind explicit live mode.

## Validation

- `git rebase origin/master` - passed, with one additive conflict in `crafter/tests/public_api.rs` resolved by keeping both public API tests.
- `.agents/scripts/check-conventional-commits --range origin/master..HEAD` - passed.
- `.agents/scripts/check-crafter-release --static` - passed.
