### PR TITLE
feat(flow): add TCP client and server flows

### DIFF
--- a/tools/flow/docs/tcp-flow.md
+++ b/tools/flow/docs/tcp-flow.md
@@ -11,14 +11,34 @@ lab or provider endpoint.
 ## Client Lifecycle
 
 The client template performs an active open and carries the connection through
-these states:
+this state machine:
 
-- `SynSent`: send the initial SYN with the local initial sequence number.
-- `Established`: accept the peer SYN-ACK, acknowledge it, send configured data,
-  and acknowledge peer data.
-- `FinWait1`: send the active-close FIN and wait for the peer acknowledgement.
-- `FinWait2`: wait for the peer FIN after the local FIN is acknowledged.
-- `Closed`: send the final ACK and finish the flow report.
+```text
+SynSent
+  entry: send SYN, store local ISS, local port, remote port, remote IPv4
+  SYN|ACK with ack == snd_nxt -> store peer rcv_nxt, send ACK -> Established
+  RST with ack == snd_nxt -> Closed
+
+Established
+  entry: optionally send one PSH|ACK data segment and advance snd_nxt
+  ACK with payload, seq == rcv_nxt, ack == snd_nxt
+    -> store payload, advance rcv_nxt, send ACK -> FinWait1
+  no configured payload or zero send window -> FinWait1
+  RST with ack == snd_nxt -> Closed
+
+FinWait1
+  entry: send FIN|ACK and advance snd_nxt
+  ACK of local FIN -> FinWait2
+  FIN|ACK from peer -> advance rcv_nxt, send final ACK -> Closed
+  RST with ack == snd_nxt -> Closed
+
+FinWait2
+  FIN|ACK from peer -> advance rcv_nxt, send final ACK -> Closed
+  RST with ack == snd_nxt -> Closed
+
+Closed
+  terminal report state
+```
 
 The client only advances when the received TCP segment belongs to the learned
 four-tuple and acknowledges the current local send-next value. Peer data updates
@@ -27,15 +47,34 @@ the receive-next value before the next acknowledgement is emitted.
 ## Server Lifecycle
 
 The server template performs a passive open and carries the connection through
-these states:
+this state machine:
 
-- `Listen`: wait for a SYN on the configured local address and port.
-- `SynReceived`: answer with SYN-ACK and wait for the final handshake ACK.
-- `Established`: receive client data, acknowledge it, and optionally emit one
-  configured response segment.
-- `CloseWait`: acknowledge the peer FIN after the peer starts the close.
-- `LastAck`: send the server FIN and wait for the peer ACK.
-- `Closed`: finish after the server FIN is acknowledged.
+```text
+Listen
+  SYN to local address and listen port
+    -> store remote IPv4/port, peer rcv_nxt, local ISS, send SYN|ACK
+    -> SynReceived
+
+SynReceived
+  ACK with seq == rcv_nxt and ack == snd_nxt -> Established
+
+Established
+  ACK with payload, seq == rcv_nxt, ack == snd_nxt
+    -> store payload, advance rcv_nxt, send ACK or one PSH|ACK response
+    -> Established
+  FIN|ACK with seq == rcv_nxt, ack == snd_nxt
+    -> store any FIN payload, advance rcv_nxt, send ACK -> CloseWait
+
+CloseWait
+  entry: send FIN|ACK and advance snd_nxt -> LastAck
+
+LastAck
+  ACK with seq == rcv_nxt, ack == snd_nxt, no payload, no FIN, no RST
+    -> Closed
+
+Closed
+  terminal report state
+```
 
 The server learns the remote address and port from the SYN. Later segments must
 match that connection tuple and the current sequence/acknowledgement state before
@@ -57,6 +96,26 @@ Outgoing ACK, data, and FIN segments are built from that carried state. Values
 set explicitly by the flow remain visible in the emitted packets, while normal
 packet compilation still fills lower-level lengths and checksums.
 
+The peer's initial sequence number is not assumed. Each acknowledgement is
+derived from the latest accepted peer SYN, payload, or FIN, and every later
+outgoing sequence number is derived from the local send-next carried across
+earlier SYN, data, and FIN sends.
+
+## Validation Status
+
+The TCP client and TCP server were validated offline with scripted in-memory
+packets, with the client and server flows driving each other without a network,
+and live against real `netcat` peers in an isolated lab:
+
+- `crafter-flow` TCP client to a `netcat` server: handshake, payload send,
+  payload receive, and graceful close.
+- `netcat` client to `crafter-flow` TCP server: passive handshake, payload
+  receive, response send, and graceful close.
+
+The live validation used isolated lab artifacts and scratch runners that are not
+tracked. The tracked documentation keeps examples neutral and documentation-space
+only.
+
 ## First-Cut Scope
 
 This is a small, single-connection TCP model:
@@ -77,8 +136,7 @@ Userspace-crafted TCP competes with the host kernel. During live runs, the kerne
 can send a RST for SYNs or data segments that do not belong to a kernel socket,
 which tears down the userspace connection before the flow can finish.
 
-Live operation therefore requires scoped kernel RST suppression in the isolated
-TCP lab. Keep the tracked flow documentation neutral and use the untracked lab
-under `tools/flow/.scratch/lab/tcp/` for the concrete guard, verification, and
-rollback commands. The guard must be limited to the lab ports and removed after
-the run.
+Live operation therefore requires the scoped kernel RST-drop guard from the
+isolated TCP lab. The concrete guard, verification, and rollback commands belong
+to the untracked lab under `tools/flow/.scratch/lab/tcp/`, not tracked code. The
+guard must be limited to the lab ports and removed after the run.

--- a/tools/flow/docs/tcp-flow.md
+++ b/tools/flow/docs/tcp-flow.md
@@ -1,0 +1,84 @@
+# TCP Flow Templates
+
+The TCP flow templates model one userspace TCP connection as a bounded flow.
+They are intended for neutral client/server interop and test harnesses built on
+top of `crafter-flow`, not as a full TCP/IP stack.
+
+All examples should use documentation address space such as `192.0.2.10` and
+`198.51.100.20`. Live use remains explicit and should stay inside an isolated
+lab or provider endpoint.
+
+## Client Lifecycle
+
+The client template performs an active open and carries the connection through
+these states:
+
+- `SynSent`: send the initial SYN with the local initial sequence number.
+- `Established`: accept the peer SYN-ACK, acknowledge it, send configured data,
+  and acknowledge peer data.
+- `FinWait1`: send the active-close FIN and wait for the peer acknowledgement.
+- `FinWait2`: wait for the peer FIN after the local FIN is acknowledged.
+- `Closed`: send the final ACK and finish the flow report.
+
+The client only advances when the received TCP segment belongs to the learned
+four-tuple and acknowledges the current local send-next value. Peer data updates
+the receive-next value before the next acknowledgement is emitted.
+
+## Server Lifecycle
+
+The server template performs a passive open and carries the connection through
+these states:
+
+- `Listen`: wait for a SYN on the configured local address and port.
+- `SynReceived`: answer with SYN-ACK and wait for the final handshake ACK.
+- `Established`: receive client data, acknowledge it, and optionally emit one
+  configured response segment.
+- `CloseWait`: acknowledge the peer FIN after the peer starts the close.
+- `LastAck`: send the server FIN and wait for the peer ACK.
+- `Closed`: finish after the server FIN is acknowledged.
+
+The server learns the remote address and port from the SYN. Later segments must
+match that connection tuple and the current sequence/acknowledgement state before
+they can move the flow forward.
+
+## Carried Connection State
+
+Each flow keeps TCP state in `PacketContext` rather than hardcoding later
+segments:
+
+- local and remote IPv4 addresses and TCP ports;
+- local initial sequence number and current send-next value;
+- remote receive-next value derived from the peer sequence number and payload
+  length;
+- peer MSS and advertised window, used to cap the first data segment;
+- received TCP payload bytes, surfaced through the flow report.
+
+Outgoing ACK, data, and FIN segments are built from that carried state. Values
+set explicitly by the flow remain visible in the emitted packets, while normal
+packet compilation still fills lower-level lengths and checksums.
+
+## First-Cut Scope
+
+This is a small, single-connection TCP model:
+
+- one IPv4/TCP connection at a time;
+- in-order handshake, payload, and graceful close;
+- a modest fixed window and one data segment sized by MSS/window state;
+- no congestion control, no SACK/window scaling behavior, no simultaneous open,
+  and no stream reassembly for large transfers.
+
+The runner bound and timeout remain the guardrails for peers that never complete
+the expected lifecycle. A stalled run should produce an inspectable partial
+report instead of hanging.
+
+## Live Kernel Suppression
+
+Userspace-crafted TCP competes with the host kernel. During live runs, the kernel
+can send a RST for SYNs or data segments that do not belong to a kernel socket,
+which tears down the userspace connection before the flow can finish.
+
+Live operation therefore requires scoped kernel RST suppression in the isolated
+TCP lab. Keep the tracked flow documentation neutral and use the untracked lab
+under `tools/flow/.scratch/lab/tcp/` for the concrete guard, verification, and
+rollback commands. The guard must be limited to the lab ports and removed after
+the run.

--- a/tools/flow/examples/tcp_client_flow.rs
+++ b/tools/flow/examples/tcp_client_flow.rs
@@ -1,0 +1,182 @@
+use crafter_flow::flows::tcp::{client_flow, SYN_SENT};
+use crafter_flow::{docaddr, MemoryCaptureSource, PacketContext, RunOptions, Runner};
+
+const REMOTE_PORT: u16 = 443;
+const PEER_ISS: u32 = 0x5152_5354;
+const PEER_WINDOW: u16 = 32_768;
+const PEER_MSS: u16 = 1_200;
+const CLIENT_PAYLOAD: &[u8] = b"client hello";
+const PEER_PAYLOAD: &[u8] = b"server reply";
+
+fn client_syn_numbers(payload: &[u8]) -> (u16, u32) {
+    let mut flow = client_flow(
+        docaddr::CLIENT_IPV4,
+        docaddr::SERVER_IPV4,
+        REMOTE_PORT,
+        Some(payload.to_vec()),
+    );
+    let mut context = PacketContext::new();
+    let step = flow
+        .state_mut(SYN_SENT)
+        .expect("SynSent state exists")
+        .run_entry(&mut context)
+        .expect("SynSent entry succeeds")
+        .expect("SynSent entry sends SYN");
+    let syn = step.outgoing().expect("SynSent entry has outgoing SYN");
+    let tcp = syn.layer::<crafter::Tcp>().expect("SYN has TCP layer");
+
+    (
+        tcp.source_port_value(),
+        context
+            .get_tcp_snd_nxt()
+            .expect("SynSent entry stores client snd_nxt"),
+    )
+}
+
+fn syn_ack_from_peer(local_port: u16, peer_seq: u32, ack: u32) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(docaddr::SERVER_IPV4)
+            .dst(docaddr::CLIENT_IPV4)
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(REMOTE_PORT)
+                .dport(local_port)
+                .seq(peer_seq)
+                .ack(ack)
+                .window(PEER_WINDOW)
+                .syn_ack_segment()
+                .tcp_option(crafter::TcpOption::maximum_segment_size(PEER_MSS))
+                .expect("fixed peer TCP MSS option encodes"),
+    )
+}
+
+fn ack_from_peer(local_port: u16, peer_seq: u32, ack: u32) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(docaddr::SERVER_IPV4)
+            .dst(docaddr::CLIENT_IPV4)
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(REMOTE_PORT)
+                .dport(local_port)
+                .seq(peer_seq)
+                .ack(ack)
+                .window(PEER_WINDOW)
+                .ack_segment(),
+    )
+}
+
+fn data_from_peer(
+    local_port: u16,
+    peer_seq: u32,
+    ack: u32,
+    payload: impl AsRef<[u8]>,
+) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(docaddr::SERVER_IPV4)
+            .dst(docaddr::CLIENT_IPV4)
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(REMOTE_PORT)
+                .dport(local_port)
+                .seq(peer_seq)
+                .ack(ack)
+                .window(PEER_WINDOW)
+                .ack_segment()
+                .psh()
+            / crafter::Raw::from_bytes(payload),
+    )
+}
+
+fn fin_ack_from_peer(local_port: u16, peer_seq: u32, ack: u32) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(docaddr::SERVER_IPV4)
+            .dst(docaddr::CLIENT_IPV4)
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(REMOTE_PORT)
+                .dport(local_port)
+                .seq(peer_seq)
+                .ack(ack)
+                .window(PEER_WINDOW)
+                .fin_ack_segment(),
+    )
+}
+
+fn decode_ipv4(packet: crafter::Packet) -> crafter::Packet {
+    let compiled = packet.compile().expect("TCP packet compiles");
+
+    crafter::Packet::decode_from_l3(crafter::NetworkLayer::Ipv4, compiled.as_bytes())
+        .expect("TCP packet decodes as IPv4")
+}
+
+fn print_send_plan(index: usize, report: &crafter::net::SendReport) -> crafter_flow::Result<()> {
+    let packet =
+        crafter::Packet::decode_from_l3(crafter::NetworkLayer::Ipv4, report.plan().bytes())?;
+    let plan = report.plan();
+
+    println!(
+        "send plan #{index}: dry_run={} interface={} mode={:?} target={:?} bytes={} summary={}",
+        report.is_dry_run(),
+        plan.interface(),
+        plan.requested_mode(),
+        plan.target(),
+        plan.len(),
+        packet.summary()
+    );
+
+    if let Some(tcp) = packet.layer::<crafter::Tcp>() {
+        println!(
+            "  tcp: source_port={} destination_port={} seq={} ack={} flags=0x{:03x} window={}",
+            tcp.source_port_value(),
+            tcp.destination_port_value(),
+            tcp.sequence_number_value(),
+            tcp.acknowledgment_number_value(),
+            tcp.flags_value(),
+            tcp.window_value()
+        );
+    }
+
+    if let Some(raw) = packet.layer::<crafter::Raw>() {
+        println!("  payload: {:?}", String::from_utf8_lossy(raw.as_bytes()));
+    }
+
+    Ok(())
+}
+
+fn main() -> crafter_flow::Result<()> {
+    let (local_port, client_snd_nxt) = client_syn_numbers(CLIENT_PAYLOAD);
+    let client_data_end = client_snd_nxt.wrapping_add(CLIENT_PAYLOAD.len() as u32);
+    let peer_data_seq = PEER_ISS.wrapping_add(1);
+    let peer_data_end = peer_data_seq.wrapping_add(PEER_PAYLOAD.len() as u32);
+    let client_fin_end = client_data_end.wrapping_add(1);
+    let source = MemoryCaptureSource::new(vec![
+        syn_ack_from_peer(local_port, PEER_ISS, client_snd_nxt),
+        ack_from_peer(local_port, peer_data_seq, client_data_end),
+        data_from_peer(local_port, peer_data_seq, client_data_end, PEER_PAYLOAD),
+        ack_from_peer(local_port, peer_data_end, client_fin_end),
+        fin_ack_from_peer(local_port, peer_data_end, client_fin_end),
+    ]);
+    let mut flow = client_flow(
+        docaddr::CLIENT_IPV4,
+        docaddr::SERVER_IPV4,
+        REMOTE_PORT,
+        Some(CLIENT_PAYLOAD.to_vec()),
+    );
+    let mut runner = Runner::with_source(RunOptions::default(), source)?;
+
+    println!("{}", flow.show());
+
+    let report = runner.run(&mut flow)?;
+
+    for (index, send_report) in runner.send_reports().iter().enumerate() {
+        print_send_plan(index, send_report)?;
+    }
+
+    println!("{}", report.show());
+
+    Ok(())
+}

--- a/tools/flow/examples/tcp_server_flow.rs
+++ b/tools/flow/examples/tcp_server_flow.rs
@@ -1,0 +1,197 @@
+use crafter_flow::flows::tcp::server_flow;
+use crafter_flow::{docaddr, FlowOutcome, MemoryCaptureSource, RunOptions, Runner};
+
+const LISTEN_PORT: u16 = 8080;
+const CLIENT_PORT: u16 = 49_153;
+const CLIENT_ISS: u32 = 0x3132_3334;
+const CLIENT_WINDOW: u16 = 32_768;
+const CLIENT_MSS: u16 = 1_200;
+const CLIENT_PAYLOAD: &[u8] = b"client request";
+const SERVER_RESPONSE: &[u8] = b"server response";
+
+fn syn_from_client(client_seq: u32) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(docaddr::CLIENT_IPV4)
+            .dst(docaddr::SERVER_IPV4)
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(CLIENT_PORT)
+                .dport(LISTEN_PORT)
+                .seq(client_seq)
+                .window(CLIENT_WINDOW)
+                .syn_segment()
+                .tcp_option(crafter::TcpOption::maximum_segment_size(CLIENT_MSS))
+                .expect("fixed client TCP MSS option encodes"),
+    )
+}
+
+fn ack_from_client(client_seq: u32, ack: u32) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(docaddr::CLIENT_IPV4)
+            .dst(docaddr::SERVER_IPV4)
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(CLIENT_PORT)
+                .dport(LISTEN_PORT)
+                .seq(client_seq)
+                .ack(ack)
+                .window(CLIENT_WINDOW)
+                .ack_segment(),
+    )
+}
+
+fn data_from_client(client_seq: u32, ack: u32, payload: impl AsRef<[u8]>) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(docaddr::CLIENT_IPV4)
+            .dst(docaddr::SERVER_IPV4)
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(CLIENT_PORT)
+                .dport(LISTEN_PORT)
+                .seq(client_seq)
+                .ack(ack)
+                .window(CLIENT_WINDOW)
+                .ack_segment()
+                .psh()
+            / crafter::Raw::from_bytes(payload),
+    )
+}
+
+fn fin_ack_from_client(client_seq: u32, ack: u32) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(docaddr::CLIENT_IPV4)
+            .dst(docaddr::SERVER_IPV4)
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(CLIENT_PORT)
+                .dport(LISTEN_PORT)
+                .seq(client_seq)
+                .ack(ack)
+                .window(CLIENT_WINDOW)
+                .fin_ack_segment(),
+    )
+}
+
+fn decode_ipv4(packet: crafter::Packet) -> crafter::Packet {
+    let compiled = packet.compile().expect("TCP packet compiles");
+
+    crafter::Packet::decode_from_l3(crafter::NetworkLayer::Ipv4, compiled.as_bytes())
+        .expect("TCP packet decodes as IPv4")
+}
+
+fn sent_packet(report: &crafter::net::SendReport) -> crafter_flow::Result<crafter::Packet> {
+    Ok(crafter::Packet::decode_from_l3(
+        crafter::NetworkLayer::Ipv4,
+        report.plan().bytes(),
+    )?)
+}
+
+fn discover_server_send_next() -> crafter_flow::Result<u32> {
+    let mut flow = server_flow(docaddr::SERVER_IPV4, LISTEN_PORT, None);
+    let mut runner = Runner::with_source(
+        RunOptions::default(),
+        MemoryCaptureSource::new(vec![syn_from_client(CLIENT_ISS)]),
+    )?;
+    let _report = runner.run(&mut flow)?;
+    let syn_ack = sent_packet(
+        runner
+            .send_reports()
+            .first()
+            .expect("SYN discovery emits SYN-ACK"),
+    )?;
+    let tcp = syn_ack
+        .layer::<crafter::Tcp>()
+        .expect("SYN-ACK has TCP layer");
+
+    Ok(tcp.sequence_number_value().wrapping_add(1))
+}
+
+fn plan_label(packet: &crafter::Packet) -> &'static str {
+    let Some(tcp) = packet.layer::<crafter::Tcp>() else {
+        return "non-TCP";
+    };
+
+    if tcp.has_syn() {
+        "SYN-ACK"
+    } else if tcp.has_fin() {
+        "FIN"
+    } else if packet.layer::<crafter::Raw>().is_some() {
+        "response"
+    } else {
+        "ACK"
+    }
+}
+
+fn print_send_plan(index: usize, report: &crafter::net::SendReport) -> crafter_flow::Result<()> {
+    let packet = sent_packet(report)?;
+    let label = plan_label(&packet);
+    let plan = report.plan();
+
+    println!(
+        "send plan #{index} ({label}): dry_run={} interface={} mode={:?} target={:?} bytes={} summary={}",
+        report.is_dry_run(),
+        plan.interface(),
+        plan.requested_mode(),
+        plan.target(),
+        plan.len(),
+        packet.summary()
+    );
+
+    if let Some(tcp) = packet.layer::<crafter::Tcp>() {
+        println!(
+            "  tcp: source_port={} destination_port={} seq={} ack={} flags=0x{:03x} window={}",
+            tcp.source_port_value(),
+            tcp.destination_port_value(),
+            tcp.sequence_number_value(),
+            tcp.acknowledgment_number_value(),
+            tcp.flags_value(),
+            tcp.window_value()
+        );
+    }
+
+    if let Some(raw) = packet.layer::<crafter::Raw>() {
+        println!("  payload: {:?}", String::from_utf8_lossy(raw.as_bytes()));
+    }
+
+    Ok(())
+}
+
+fn main() -> crafter_flow::Result<()> {
+    let server_snd_nxt = discover_server_send_next()?;
+    let client_snd_nxt = CLIENT_ISS.wrapping_add(1);
+    let client_data_end = client_snd_nxt.wrapping_add(CLIENT_PAYLOAD.len() as u32);
+    let server_response_end = server_snd_nxt.wrapping_add(SERVER_RESPONSE.len() as u32);
+    let client_fin_end = client_data_end.wrapping_add(1);
+    let server_fin_end = server_response_end.wrapping_add(1);
+    let source = MemoryCaptureSource::new(vec![
+        syn_from_client(CLIENT_ISS),
+        ack_from_client(client_snd_nxt, server_snd_nxt),
+        data_from_client(client_snd_nxt, server_snd_nxt, CLIENT_PAYLOAD),
+        fin_ack_from_client(client_data_end, server_response_end),
+        ack_from_client(client_fin_end, server_fin_end),
+    ]);
+    let mut flow = server_flow(
+        docaddr::SERVER_IPV4,
+        LISTEN_PORT,
+        Some(SERVER_RESPONSE.to_vec()),
+    );
+    let mut runner = Runner::with_source(RunOptions::default(), source)?;
+
+    println!("{}", flow.show());
+
+    let report = runner.run(&mut flow)?;
+
+    for (index, send_report) in runner.send_reports().iter().enumerate() {
+        print_send_plan(index, send_report)?;
+    }
+
+    println!("{}", report.show());
+
+    assert_eq!(report.outcome(), &FlowOutcome::Completed);
+
+    Ok(())
+}

--- a/tools/flow/src/context.rs
+++ b/tools/flow/src/context.rs
@@ -12,6 +12,14 @@ const ASSIGNED_IPV4: &str = "assigned_ipv4";
 const SERVER_IDENTIFIER: &str = "server_identifier";
 const DNS_TRANSACTION_ID: &str = "dns_transaction_id";
 const DNS_QUESTION_NAME: &str = "dns_question_name";
+const TCP_SND_NXT: &str = "tcp_snd_nxt";
+const TCP_RCV_NXT: &str = "tcp_rcv_nxt";
+const TCP_ISS: &str = "tcp_iss";
+const TCP_LOCAL_PORT: &str = "tcp_local_port";
+const TCP_REMOTE_PORT: &str = "tcp_remote_port";
+const TCP_REMOTE_IPV4: &str = "tcp_remote_ipv4";
+const TCP_PEER_MSS: &str = "tcp_peer_mss";
+const TCP_PEER_WINDOW: &str = "tcp_peer_window";
 
 /// Typed in-memory values carried through one flow run.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -139,6 +147,118 @@ impl PacketContext {
         }
     }
 
+    /// Store the next TCP sequence number to send.
+    pub fn set_tcp_snd_nxt(&mut self, value: u32) {
+        self.values
+            .insert(TCP_SND_NXT.to_string(), ContextValue::U32(value));
+    }
+
+    /// Return the next TCP sequence number to send.
+    pub fn get_tcp_snd_nxt(&self) -> Option<u32> {
+        match self.values.get(TCP_SND_NXT) {
+            Some(ContextValue::U32(value)) => Some(*value),
+            _ => None,
+        }
+    }
+
+    /// Store the next expected peer TCP sequence number.
+    pub fn set_tcp_rcv_nxt(&mut self, value: u32) {
+        self.values
+            .insert(TCP_RCV_NXT.to_string(), ContextValue::U32(value));
+    }
+
+    /// Return the next expected peer TCP sequence number.
+    pub fn get_tcp_rcv_nxt(&self) -> Option<u32> {
+        match self.values.get(TCP_RCV_NXT) {
+            Some(ContextValue::U32(value)) => Some(*value),
+            _ => None,
+        }
+    }
+
+    /// Store our initial TCP send sequence number.
+    pub fn set_tcp_iss(&mut self, value: u32) {
+        self.values
+            .insert(TCP_ISS.to_string(), ContextValue::U32(value));
+    }
+
+    /// Return our initial TCP send sequence number.
+    pub fn get_tcp_iss(&self) -> Option<u32> {
+        match self.values.get(TCP_ISS) {
+            Some(ContextValue::U32(value)) => Some(*value),
+            _ => None,
+        }
+    }
+
+    /// Store the local TCP port for the current connection.
+    pub fn set_tcp_local_port(&mut self, value: u16) {
+        self.values
+            .insert(TCP_LOCAL_PORT.to_string(), ContextValue::U16(value));
+    }
+
+    /// Return the local TCP port for the current connection.
+    pub fn get_tcp_local_port(&self) -> Option<u16> {
+        match self.values.get(TCP_LOCAL_PORT) {
+            Some(ContextValue::U16(value)) => Some(*value),
+            _ => None,
+        }
+    }
+
+    /// Store the remote TCP port for the current connection.
+    pub fn set_tcp_remote_port(&mut self, value: u16) {
+        self.values
+            .insert(TCP_REMOTE_PORT.to_string(), ContextValue::U16(value));
+    }
+
+    /// Return the remote TCP port for the current connection.
+    pub fn get_tcp_remote_port(&self) -> Option<u16> {
+        match self.values.get(TCP_REMOTE_PORT) {
+            Some(ContextValue::U16(value)) => Some(*value),
+            _ => None,
+        }
+    }
+
+    /// Store the remote IPv4 address for the current TCP connection.
+    pub fn set_tcp_remote_ipv4(&mut self, value: Ipv4Addr) {
+        self.values
+            .insert(TCP_REMOTE_IPV4.to_string(), ContextValue::Ipv4(value));
+    }
+
+    /// Return the remote IPv4 address for the current TCP connection.
+    pub fn get_tcp_remote_ipv4(&self) -> Option<Ipv4Addr> {
+        match self.values.get(TCP_REMOTE_IPV4) {
+            Some(ContextValue::Ipv4(value)) => Some(*value),
+            _ => None,
+        }
+    }
+
+    /// Store the peer's advertised TCP MSS.
+    pub fn set_tcp_peer_mss(&mut self, value: u16) {
+        self.values
+            .insert(TCP_PEER_MSS.to_string(), ContextValue::U16(value));
+    }
+
+    /// Return the peer's advertised TCP MSS.
+    pub fn get_tcp_peer_mss(&self) -> Option<u16> {
+        match self.values.get(TCP_PEER_MSS) {
+            Some(ContextValue::U16(value)) => Some(*value),
+            _ => None,
+        }
+    }
+
+    /// Store the peer's advertised TCP window.
+    pub fn set_tcp_peer_window(&mut self, value: u16) {
+        self.values
+            .insert(TCP_PEER_WINDOW.to_string(), ContextValue::U16(value));
+    }
+
+    /// Return the peer's advertised TCP window.
+    pub fn get_tcp_peer_window(&self) -> Option<u16> {
+        match self.values.get(TCP_PEER_WINDOW) {
+            Some(ContextValue::U16(value)) => Some(*value),
+            _ => None,
+        }
+    }
+
     /// Return a compact inspectable list of currently set keys.
     pub fn summary(&self) -> String {
         let keys = self.values.keys().cloned().collect::<Vec<_>>().join(", ");
@@ -186,6 +306,14 @@ mod tests {
 
         assert_eq!(context.get_transaction_id(), None);
         assert_eq!(context.get_offered_ipv4(), None);
+        assert_eq!(context.get_tcp_snd_nxt(), None);
+        assert_eq!(context.get_tcp_rcv_nxt(), None);
+        assert_eq!(context.get_tcp_iss(), None);
+        assert_eq!(context.get_tcp_local_port(), None);
+        assert_eq!(context.get_tcp_remote_port(), None);
+        assert_eq!(context.get_tcp_remote_ipv4(), None);
+        assert_eq!(context.get_tcp_peer_mss(), None);
+        assert_eq!(context.get_tcp_peer_window(), None);
     }
 
     #[test]
@@ -198,5 +326,53 @@ mod tests {
         let summary = context.summary();
         assert!(summary.contains("transaction_id"));
         assert!(summary.contains("offered_ipv4"));
+    }
+
+    #[test]
+    fn context_round_trips_tcp_fields() {
+        let mut context = PacketContext::new();
+        let remote = Ipv4Addr::new(198, 51, 100, 20);
+
+        context.set_tcp_snd_nxt(0x0102_0304);
+        context.set_tcp_rcv_nxt(0x1112_1314);
+        context.set_tcp_iss(0x2122_2324);
+        context.set_tcp_local_port(49_152);
+        context.set_tcp_remote_port(443);
+        context.set_tcp_remote_ipv4(remote);
+        context.set_tcp_peer_mss(1_460);
+        context.set_tcp_peer_window(65_535);
+
+        assert_eq!(context.get_tcp_snd_nxt(), Some(0x0102_0304));
+        assert_eq!(context.get_tcp_rcv_nxt(), Some(0x1112_1314));
+        assert_eq!(context.get_tcp_iss(), Some(0x2122_2324));
+        assert_eq!(context.get_tcp_local_port(), Some(49_152));
+        assert_eq!(context.get_tcp_remote_port(), Some(443));
+        assert_eq!(context.get_tcp_remote_ipv4(), Some(remote));
+        assert_eq!(context.get_tcp_peer_mss(), Some(1_460));
+        assert_eq!(context.get_tcp_peer_window(), Some(65_535));
+    }
+
+    #[test]
+    fn context_summary_lists_set_tcp_keys() {
+        let mut context = PacketContext::new();
+
+        context.set_tcp_snd_nxt(1);
+        context.set_tcp_rcv_nxt(2);
+        context.set_tcp_iss(3);
+        context.set_tcp_local_port(4);
+        context.set_tcp_remote_port(5);
+        context.set_tcp_remote_ipv4(Ipv4Addr::new(203, 0, 113, 9));
+        context.set_tcp_peer_mss(6);
+        context.set_tcp_peer_window(7);
+
+        let summary = context.summary();
+        assert!(summary.contains("tcp_snd_nxt"));
+        assert!(summary.contains("tcp_rcv_nxt"));
+        assert!(summary.contains("tcp_iss"));
+        assert!(summary.contains("tcp_local_port"));
+        assert!(summary.contains("tcp_remote_port"));
+        assert!(summary.contains("tcp_remote_ipv4"));
+        assert!(summary.contains("tcp_peer_mss"));
+        assert!(summary.contains("tcp_peer_window"));
     }
 }

--- a/tools/flow/src/context.rs
+++ b/tools/flow/src/context.rs
@@ -20,6 +20,7 @@ const TCP_REMOTE_PORT: &str = "tcp_remote_port";
 const TCP_REMOTE_IPV4: &str = "tcp_remote_ipv4";
 const TCP_PEER_MSS: &str = "tcp_peer_mss";
 const TCP_PEER_WINDOW: &str = "tcp_peer_window";
+const TCP_RECEIVED_PAYLOAD: &str = "tcp_received_payload";
 
 /// Typed in-memory values carried through one flow run.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -259,6 +260,27 @@ impl PacketContext {
         }
     }
 
+    /// Append received TCP payload bytes for the current connection.
+    pub fn append_tcp_payload(&mut self, bytes: &[u8]) {
+        match self.values.get_mut(TCP_RECEIVED_PAYLOAD) {
+            Some(ContextValue::Bytes(value)) => value.extend_from_slice(bytes),
+            Some(_) | None => {
+                self.values.insert(
+                    TCP_RECEIVED_PAYLOAD.to_string(),
+                    ContextValue::Bytes(bytes.to_vec()),
+                );
+            }
+        }
+    }
+
+    /// Return received TCP payload bytes accumulated for the current connection.
+    pub fn tcp_received_payload(&self) -> &[u8] {
+        match self.values.get(TCP_RECEIVED_PAYLOAD) {
+            Some(ContextValue::Bytes(value)) => value.as_slice(),
+            _ => &[],
+        }
+    }
+
     /// Return a compact inspectable list of currently set keys.
     pub fn summary(&self) -> String {
         let keys = self.values.keys().cloned().collect::<Vec<_>>().join(", ");
@@ -314,6 +336,7 @@ mod tests {
         assert_eq!(context.get_tcp_remote_ipv4(), None);
         assert_eq!(context.get_tcp_peer_mss(), None);
         assert_eq!(context.get_tcp_peer_window(), None);
+        assert_eq!(context.tcp_received_payload(), b"");
     }
 
     #[test]
@@ -353,6 +376,16 @@ mod tests {
     }
 
     #[test]
+    fn context_appends_tcp_payload_chunks() {
+        let mut context = PacketContext::new();
+
+        context.append_tcp_payload(b"hello ");
+        context.append_tcp_payload(b"peer");
+
+        assert_eq!(context.tcp_received_payload(), b"hello peer");
+    }
+
+    #[test]
     fn context_summary_lists_set_tcp_keys() {
         let mut context = PacketContext::new();
 
@@ -364,6 +397,7 @@ mod tests {
         context.set_tcp_remote_ipv4(Ipv4Addr::new(203, 0, 113, 9));
         context.set_tcp_peer_mss(6);
         context.set_tcp_peer_window(7);
+        context.append_tcp_payload(b"abc");
 
         let summary = context.summary();
         assert!(summary.contains("tcp_snd_nxt"));
@@ -374,5 +408,6 @@ mod tests {
         assert!(summary.contains("tcp_remote_ipv4"));
         assert!(summary.contains("tcp_peer_mss"));
         assert!(summary.contains("tcp_peer_window"));
+        assert!(summary.contains("tcp_received_payload"));
     }
 }

--- a/tools/flow/src/flows/mod.rs
+++ b/tools/flow/src/flows/mod.rs
@@ -4,3 +4,18 @@ pub mod arp;
 pub mod dhcpv4;
 pub mod dns;
 pub mod tcp;
+
+#[cfg(test)]
+mod tests {
+    use crate as crafter_flow;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn tcp_flow_entrypoints_are_public() {
+        use crafter_flow::flows::tcp::{client_flow, server_flow};
+
+        let _client_flow: fn(Ipv4Addr, Ipv4Addr, u16, Option<Vec<u8>>) -> crafter_flow::Flow =
+            client_flow;
+        let _server_flow: fn(Ipv4Addr, u16, Option<Vec<u8>>) -> crafter_flow::Flow = server_flow;
+    }
+}

--- a/tools/flow/src/flows/mod.rs
+++ b/tools/flow/src/flows/mod.rs
@@ -3,3 +3,4 @@
 pub mod arp;
 pub mod dhcpv4;
 pub mod dns;
+pub mod tcp;

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -239,7 +239,7 @@ pub fn server_flow(local_ip: Ipv4Addr, listen_port: u16) -> Flow {
         .role(Role::Responder)
         .state(server_listen_state(local_ip, listen_port))
         .state(server_syn_received_state(local_ip, listen_port))
-        .state(stub_state(ESTABLISHED, CLOSE_WAIT))
+        .state(server_established_state(local_ip, listen_port))
         .state(stub_state(CLOSE_WAIT, LAST_ACK))
         .state(stub_state(LAST_ACK, CLOSED))
         .state(terminal_state(CLOSED))
@@ -569,6 +569,10 @@ fn server_syn_received_state(local_ip: Ipv4Addr, listen_port: u16) -> FlowState 
     FlowState::new(SYN_RECEIVED).on(server_final_ack_transition(local_ip, listen_port))
 }
 
+fn server_established_state(local_ip: Ipv4Addr, listen_port: u16) -> FlowState {
+    FlowState::new(ESTABLISHED).on(server_data_transition(local_ip, listen_port))
+}
+
 fn server_syn_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
     let matcher = predicate("tcp SYN to listen port", move |packet, _ctx| {
         let Some(ipv4) = packet.layer::<crafter::Ipv4>() else {
@@ -650,6 +654,65 @@ fn server_final_ack_matcher(local_ip: Ipv4Addr, listen_port: u16) -> impl crate:
             packet.layer::<crafter::Tcp>().is_some_and(|tcp| {
                 ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value())
             })
+        },
+    )
+}
+
+fn server_data_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
+    Transition::on(server_data_matcher(local_ip, listen_port), move |packet, ctx| {
+        let raw = packet.layer::<crafter::Raw>().ok_or_else(|| {
+            FlowError::Capture("matched TCP server data packet has no Raw payload".to_string())
+        })?;
+        let payload = raw.as_bytes();
+        let rcv_nxt = tcp_rcv_nxt(ctx).wrapping_add(payload.len() as u32);
+
+        ctx.append_tcp_payload(payload);
+        ctx.set_tcp_rcv_nxt(rcv_nxt);
+
+        let remote_ip = ctx.get_tcp_remote_ipv4().ok_or_else(|| {
+            FlowError::Capture("matched TCP server data packet has no remote IPv4".to_string())
+        })?;
+        let remote_port = ctx.get_tcp_remote_port().ok_or_else(|| {
+            FlowError::Capture("matched TCP server data packet has no remote port".to_string())
+        })?;
+        let ack = ack_segment(ctx, local_ip, listen_port, remote_ip, remote_port);
+
+        Ok(Step::send(ack))
+    })
+}
+
+fn server_data_matcher(local_ip: Ipv4Addr, listen_port: u16) -> impl crate::Matcher {
+    predicate(
+        "tcp server data seq == tcp_rcv_nxt and payload length > 0",
+        move |packet, ctx| {
+            let Some(remote_ip) = ctx.get_tcp_remote_ipv4() else {
+                return false;
+            };
+            let Some(remote_port) = ctx.get_tcp_remote_port() else {
+                return false;
+            };
+
+            let matcher = tcp_segment_for_ipv4(
+                local_ip,
+                listen_port,
+                remote_ip,
+                remote_port,
+                crafter::TCP_FLAG_ACK,
+            )
+            .ack_matches_tcp_snd_nxt();
+            if !matcher.matches(packet, ctx) {
+                return false;
+            }
+
+            let Some(tcp) = packet.layer::<crafter::Tcp>() else {
+                return false;
+            };
+            let Some(raw) = packet.layer::<crafter::Raw>() else {
+                return false;
+            };
+
+            !raw.as_bytes().is_empty()
+                && ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value())
         },
     )
 }
@@ -924,6 +987,64 @@ mod tests {
         assert_eq!(step.target(), Some(ESTABLISHED));
         assert_eq!(context.get_tcp_snd_nxt(), Some(server_snd_nxt));
         assert_eq!(context.get_tcp_rcv_nxt(), Some(client_rcv_nxt));
+    }
+
+    #[test]
+    fn tcp_server_established_transition_stores_client_data_and_sends_ack() {
+        const CLIENT_PORT: u16 = 49_153;
+        const LISTEN_PORT: u16 = 8080;
+
+        let payload = b"client request";
+        let mut flow = server_flow(local_ipv4(), LISTEN_PORT);
+        let mut context = tcp_context();
+        context.set_tcp_local_port(LISTEN_PORT);
+        context.set_tcp_remote_port(CLIENT_PORT);
+        context.set_tcp_remote_ipv4(remote_ipv4());
+
+        let client_data = data_to_server(RCV_NXT, SND_NXT, CLIENT_PORT, LISTEN_PORT, payload);
+        let wrong_seq = data_to_server(
+            RCV_NXT.wrapping_add(1),
+            SND_NXT,
+            CLIENT_PORT,
+            LISTEN_PORT,
+            payload,
+        );
+        let client_ack = ack_to_server(RCV_NXT, SND_NXT, CLIENT_PORT, LISTEN_PORT);
+
+        {
+            let established = flow.state(ESTABLISHED).expect("Established state exists");
+            let transition = &established.transitions()[0];
+            assert!(transition.matches(&client_data, &context));
+            assert!(
+                !transition.matches(&wrong_seq, &context),
+                "Established transition must reject out-of-order client data"
+            );
+            assert!(
+                !transition.matches(&client_ack, &context),
+                "Established transition must reject payload-free ACKs"
+            );
+        }
+
+        let step = flow
+            .state_mut(ESTABLISHED)
+            .expect("Established state exists")
+            .find_transition(&client_data, &context)
+            .expect("client data transition matches")
+            .fire(&client_data, &mut context)
+            .expect("client data transition should fire");
+        let ack = step.outgoing().expect("client data transition sends ACK");
+        let tcp = ack.layer::<crafter::Tcp>().expect("TCP layer");
+        let expected_rcv_nxt = RCV_NXT.wrapping_add(payload.len() as u32);
+
+        assert_eq!(context.tcp_received_payload(), payload);
+        assert_eq!(context.get_tcp_rcv_nxt(), Some(expected_rcv_nxt));
+        assert_eq!(tcp.source_port_value(), LISTEN_PORT);
+        assert_eq!(tcp.destination_port_value(), CLIENT_PORT);
+        assert_eq!(tcp.sequence_number_value(), SND_NXT);
+        assert_eq!(tcp.acknowledgment_number_value(), expected_rcv_nxt);
+        assert_eq!(tcp.flags_value(), TCP_FLAG_ACK);
+        assert_eq!(step.target(), None);
+        assert!(step.expects_reply());
     }
 
     #[test]
@@ -1412,6 +1533,32 @@ mod tests {
                 .dst(local_ipv4())
                 .protocol(crafter::IPPROTO_TCP)
                 / tcp,
+        )
+    }
+
+    fn data_to_server(
+        client_seq: u32,
+        ack: u32,
+        client_port: u16,
+        listen_port: u16,
+        payload: impl AsRef<[u8]>,
+    ) -> Packet {
+        let tcp = crafter::Tcp::new()
+            .sport(client_port)
+            .dport(listen_port)
+            .seq(client_seq)
+            .ack(ack)
+            .window(TCP_WINDOW)
+            .ack_segment()
+            .psh();
+
+        compiled_ipv4(
+            crafter::Ipv4::new()
+                .src(remote_ipv4())
+                .dst(local_ipv4())
+                .protocol(crafter::IPPROTO_TCP)
+                / tcp
+                / crafter::Raw::from_bytes(payload),
         )
     }
 

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -229,7 +229,7 @@ pub fn client_flow(
     flow
 }
 
-/// Build the TCP server flow scaffold.
+/// Build the TCP server flow.
 ///
 /// The server starts in passive-open Listen and answers the first matching SYN.
 /// When `response` is set, received client data is answered with that payload.
@@ -975,6 +975,7 @@ mod tests {
 
         assert_eq!(flow.role(), Role::Responder);
         assert_eq!(flow.initial(), LISTEN);
+        assert!(flow.validate().is_ok());
         assert_named_states(
             &flow,
             &[LISTEN, SYN_RECEIVED, ESTABLISHED, CLOSE_WAIT, LAST_ACK, CLOSED],
@@ -983,15 +984,27 @@ mod tests {
         assert!(!listen.has_entry(), "Listen must not send on entry");
         assert_eq!(listen.transitions().len(), 1);
         let show = flow.show();
-        assert!(
-            show.contains("tcp SYN to listen port"),
-            "show() missing server SYN transition detail:\n{show}"
-        );
-        assert!(
-            show.contains("-> SynReceived"),
-            "show() missing server SYN transition target:\n{show}"
-        );
-        flow.validate().expect("TCP server scaffold is valid");
+        for expected in [LISTEN, SYN_RECEIVED, ESTABLISHED, CLOSE_WAIT, LAST_ACK, CLOSED] {
+            assert!(show.contains(expected), "show() missing state {expected}");
+        }
+        for expected in [
+            "tcp SYN to listen port",
+            "-> SynReceived",
+            "tcp final ACK for stored four-tuple",
+            "-> Established",
+            "tcp server data seq == tcp_rcv_nxt",
+            "tcp server FIN seq == tcp_rcv_nxt",
+            "-> CloseWait",
+            "TCP FIN-ACK passive close",
+            "-> LastAck",
+            "tcp server final ACK seq == tcp_rcv_nxt",
+            "-> Closed [terminal]",
+        ] {
+            assert!(
+                show.contains(expected),
+                "show() missing server transition detail {expected:?}:\n{show}"
+            );
+        }
     }
 
     #[test]

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -9,7 +9,8 @@ use std::net::Ipv4Addr;
 
 use crate::matcher::{predicate, tcp_segment_for_ipv4, MatcherExt};
 use crate::{
-    Flow, FlowBuilderExt, FlowError, FlowState, PacketContext, Role, Step, StepGotoExt, Transition,
+    Flow, FlowBuilderExt, FlowError, FlowState, Matcher, PacketContext, Role, Step, StepGotoExt,
+    Transition,
 };
 
 const TCP_WINDOW: u16 = 64_240;
@@ -237,7 +238,7 @@ pub fn server_flow(local_ip: Ipv4Addr, listen_port: u16) -> Flow {
     let flow = Flow::new("tcp-server")
         .role(Role::Responder)
         .state(server_listen_state(local_ip, listen_port))
-        .state(stub_state(SYN_RECEIVED, ESTABLISHED))
+        .state(server_syn_received_state(local_ip, listen_port))
         .state(stub_state(ESTABLISHED, CLOSE_WAIT))
         .state(stub_state(CLOSE_WAIT, LAST_ACK))
         .state(stub_state(LAST_ACK, CLOSED))
@@ -564,6 +565,10 @@ fn server_listen_state(local_ip: Ipv4Addr, listen_port: u16) -> FlowState {
     FlowState::new(LISTEN).on(server_syn_transition(local_ip, listen_port))
 }
 
+fn server_syn_received_state(local_ip: Ipv4Addr, listen_port: u16) -> FlowState {
+    FlowState::new(SYN_RECEIVED).on(server_final_ack_transition(local_ip, listen_port))
+}
+
 fn server_syn_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
     let matcher = predicate("tcp SYN to listen port", move |packet, _ctx| {
         let Some(ipv4) = packet.layer::<crafter::Ipv4>() else {
@@ -610,6 +615,43 @@ fn server_syn_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
         Ok(Step::send(syn_ack).goto(SYN_RECEIVED))
     })
     .targets([SYN_RECEIVED])
+}
+
+fn server_final_ack_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
+    Transition::on(server_final_ack_matcher(local_ip, listen_port), |_packet, _ctx| {
+        Ok(Step::goto(ESTABLISHED))
+    })
+    .targets([ESTABLISHED])
+}
+
+fn server_final_ack_matcher(local_ip: Ipv4Addr, listen_port: u16) -> impl crate::Matcher {
+    predicate(
+        "tcp final ACK for stored four-tuple and seq == tcp_rcv_nxt",
+        move |packet, ctx| {
+            let Some(remote_ip) = ctx.get_tcp_remote_ipv4() else {
+                return false;
+            };
+            let Some(remote_port) = ctx.get_tcp_remote_port() else {
+                return false;
+            };
+
+            let matcher = tcp_segment_for_ipv4(
+                local_ip,
+                listen_port,
+                remote_ip,
+                remote_port,
+                crafter::TCP_FLAG_ACK,
+            )
+            .ack_matches_tcp_snd_nxt();
+            if !matcher.matches(packet, ctx) {
+                return false;
+            }
+
+            packet.layer::<crafter::Tcp>().is_some_and(|tcp| {
+                ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value())
+            })
+        },
+    )
 }
 
 fn stub_state(name: &'static str, next: &'static str) -> FlowState {
@@ -813,6 +855,75 @@ mod tests {
         assert_eq!(tcp.flags_value(), TCP_FLAG_SYN | TCP_FLAG_ACK);
         assert_has_mss(tcp);
         assert_eq!(step.target(), Some(SYN_RECEIVED));
+    }
+
+    #[test]
+    fn tcp_server_syn_received_transition_accepts_final_ack_and_reaches_established() {
+        const CLIENT_ISS: u32 = 0x5152_5354;
+        const CLIENT_PORT: u16 = 49_153;
+        const LISTEN_PORT: u16 = 8080;
+
+        let mut flow = server_flow(local_ipv4(), LISTEN_PORT);
+        let mut context = PacketContext::new();
+        let syn = syn_to_server(CLIENT_ISS, CLIENT_PORT, LISTEN_PORT, TCP_WINDOW, TCP_MSS);
+
+        let listen_step = flow
+            .state_mut(LISTEN)
+            .expect("Listen state exists")
+            .find_transition(&syn, &context)
+            .expect("SYN transition matches")
+            .fire(&syn, &mut context)
+            .expect("SYN transition should fire");
+        assert_eq!(listen_step.target(), Some(SYN_RECEIVED));
+
+        let server_snd_nxt = context
+            .get_tcp_snd_nxt()
+            .expect("SYN transition records server snd_nxt");
+        let client_rcv_nxt = context
+            .get_tcp_rcv_nxt()
+            .expect("SYN transition records client rcv_nxt");
+        let final_ack = ack_to_server(client_rcv_nxt, server_snd_nxt, CLIENT_PORT, LISTEN_PORT);
+        let wrong_ack = ack_to_server(
+            client_rcv_nxt,
+            server_snd_nxt.wrapping_add(1),
+            CLIENT_PORT,
+            LISTEN_PORT,
+        );
+        let wrong_seq = ack_to_server(
+            client_rcv_nxt.wrapping_add(1),
+            server_snd_nxt,
+            CLIENT_PORT,
+            LISTEN_PORT,
+        );
+
+        {
+            let syn_received = flow
+                .state(SYN_RECEIVED)
+                .expect("SynReceived state exists");
+            let transition = &syn_received.transitions()[0];
+            assert!(transition.matches(&final_ack, &context));
+            assert!(
+                !transition.matches(&wrong_ack, &context),
+                "SynReceived transition must reject ACKs that do not acknowledge server snd_nxt"
+            );
+            assert!(
+                !transition.matches(&wrong_seq, &context),
+                "SynReceived transition must reject ACKs with unexpected client sequence"
+            );
+        }
+
+        let step = flow
+            .state_mut(SYN_RECEIVED)
+            .expect("SynReceived state exists")
+            .find_transition(&final_ack, &context)
+            .expect("final ACK transition matches")
+            .fire(&final_ack, &mut context)
+            .expect("final ACK transition should fire");
+
+        assert!(step.outgoing().is_none());
+        assert_eq!(step.target(), Some(ESTABLISHED));
+        assert_eq!(context.get_tcp_snd_nxt(), Some(server_snd_nxt));
+        assert_eq!(context.get_tcp_rcv_nxt(), Some(client_rcv_nxt));
     }
 
     #[test]
@@ -1276,6 +1387,24 @@ mod tests {
             .ack(TCP_SERVER_ISS.wrapping_add(1))
             .window(TCP_WINDOW)
             .syn_ack_segment();
+
+        compiled_ipv4(
+            crafter::Ipv4::new()
+                .src(remote_ipv4())
+                .dst(local_ipv4())
+                .protocol(crafter::IPPROTO_TCP)
+                / tcp,
+        )
+    }
+
+    fn ack_to_server(client_seq: u32, ack: u32, client_port: u16, listen_port: u16) -> Packet {
+        let tcp = crafter::Tcp::new()
+            .sport(client_port)
+            .dport(listen_port)
+            .seq(client_seq)
+            .ack(ack)
+            .window(TCP_WINDOW)
+            .ack_segment();
 
         compiled_ipv4(
             crafter::Ipv4::new()

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -7,7 +7,7 @@
 
 use std::net::Ipv4Addr;
 
-use crate::matcher::tcp_segment_for_ipv4;
+use crate::matcher::{predicate, tcp_segment_for_ipv4, MatcherExt};
 use crate::{
     Flow, FlowBuilderExt, FlowError, FlowState, PacketContext, Role, Step, StepGotoExt, Transition,
 };
@@ -334,6 +334,57 @@ fn client_established_state(
         })
         .entry_description("TCP PSH-ACK data")
         .entry_targets([FIN_WAIT_1])
+        .on(client_data_transition(local_ip, remote_ip, remote_port))
+}
+
+fn client_data_transition(
+    local_ip: Ipv4Addr,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
+) -> Transition {
+    let matcher = tcp_segment_for_ipv4(
+        local_ip,
+        TCP_CLIENT_LOCAL_PORT,
+        remote_ip,
+        remote_port,
+        crafter::TCP_FLAG_ACK,
+    )
+    .ack_matches_tcp_snd_nxt()
+    .and(predicate(
+        "tcp data seq == tcp_rcv_nxt and payload length > 0",
+        |packet, ctx| {
+            let Some(tcp) = packet.layer::<crafter::Tcp>() else {
+                return false;
+            };
+            let Some(raw) = packet.layer::<crafter::Raw>() else {
+                return false;
+            };
+
+            !raw.as_bytes().is_empty()
+                && ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value())
+        },
+    ));
+
+    Transition::on(matcher, move |packet, ctx| {
+        let raw = packet.layer::<crafter::Raw>().ok_or_else(|| {
+            FlowError::Capture("matched TCP data packet has no Raw payload".to_string())
+        })?;
+        let payload = raw.as_bytes();
+        let rcv_nxt = tcp_rcv_nxt(ctx).wrapping_add(payload.len() as u32);
+
+        ctx.append_tcp_payload(payload);
+        ctx.set_tcp_rcv_nxt(rcv_nxt);
+
+        let ack = ack_segment(
+            ctx,
+            local_ip,
+            TCP_CLIENT_LOCAL_PORT,
+            remote_ip,
+            remote_port,
+        );
+
+        Ok(Step::send(ack))
+    })
 }
 
 fn stub_state(name: &'static str, next: &'static str) -> FlowState {
@@ -571,6 +622,44 @@ mod tests {
         );
     }
 
+    #[test]
+    fn tcp_client_established_transition_stores_peer_data_and_sends_ack() {
+        let payload = b"server reply";
+        let mut flow = client_flow(local_ipv4(), remote_ipv4(), REMOTE_PORT, None);
+        let mut context = tcp_context();
+        let peer_data = data_from_peer(RCV_NXT, SND_NXT, payload);
+        let wrong_seq = data_from_peer(RCV_NXT.wrapping_add(1), SND_NXT, payload);
+        let peer_ack = ack_from_peer(RCV_NXT, SND_NXT);
+
+        {
+            let established = flow.state(ESTABLISHED).expect("Established state exists");
+            let transition = &established.transitions()[0];
+            assert!(transition.matches(&peer_data, &context));
+            assert!(!transition.matches(&wrong_seq, &context));
+            assert!(!transition.matches(&peer_ack, &context));
+        }
+
+        let step = flow
+            .state_mut(ESTABLISHED)
+            .expect("Established state exists")
+            .find_transition(&peer_data, &context)
+            .expect("TCP peer data transition matches")
+            .fire(&peer_data, &mut context)
+            .expect("TCP peer data transition should fire");
+        let ack = step.outgoing().expect("peer data transition sends ACK");
+        let tcp = ack.layer::<crafter::Tcp>().expect("TCP layer");
+        let expected_rcv_nxt = RCV_NXT.wrapping_add(payload.len() as u32);
+
+        assert_eq!(context.tcp_received_payload(), payload);
+        assert_eq!(context.get_tcp_rcv_nxt(), Some(expected_rcv_nxt));
+        assert_eq!(tcp.source_port_value(), TCP_CLIENT_LOCAL_PORT);
+        assert_eq!(tcp.destination_port_value(), REMOTE_PORT);
+        assert_eq!(tcp.sequence_number_value(), SND_NXT);
+        assert_eq!(tcp.acknowledgment_number_value(), expected_rcv_nxt);
+        assert_eq!(tcp.flags_value(), TCP_FLAG_ACK);
+        assert_eq!(step.target(), None);
+    }
+
     fn assert_named_states(flow: &crate::Flow, expected: &[&str]) {
         for name in expected {
             assert!(flow.state(name).is_some(), "missing {name} state");
@@ -714,6 +803,44 @@ mod tests {
             .syn_ack_segment()
             .tcp_option(TcpOption::maximum_segment_size(mss))
             .expect("fixed peer TCP MSS option encodes");
+
+        compiled_ipv4(
+            crafter::Ipv4::new()
+                .src(remote_ipv4())
+                .dst(local_ipv4())
+                .protocol(crafter::IPPROTO_TCP)
+                / tcp,
+        )
+    }
+
+    fn data_from_peer(peer_seq: u32, ack: u32, payload: impl AsRef<[u8]>) -> Packet {
+        let tcp = crafter::Tcp::new()
+            .sport(REMOTE_PORT)
+            .dport(TCP_CLIENT_LOCAL_PORT)
+            .seq(peer_seq)
+            .ack(ack)
+            .window(TCP_WINDOW)
+            .ack_segment()
+            .psh();
+
+        compiled_ipv4(
+            crafter::Ipv4::new()
+                .src(remote_ipv4())
+                .dst(local_ipv4())
+                .protocol(crafter::IPPROTO_TCP)
+                / tcp
+                / crafter::Raw::from_bytes(payload),
+        )
+    }
+
+    fn ack_from_peer(peer_seq: u32, ack: u32) -> Packet {
+        let tcp = crafter::Tcp::new()
+            .sport(REMOTE_PORT)
+            .dport(TCP_CLIENT_LOCAL_PORT)
+            .seq(peer_seq)
+            .ack(ack)
+            .window(TCP_WINDOW)
+            .ack_segment();
 
         compiled_ipv4(
             crafter::Ipv4::new()

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -206,12 +206,17 @@ pub fn client_flow(
     local_ip: Ipv4Addr,
     remote_ip: Ipv4Addr,
     remote_port: u16,
-    _payload: Option<Vec<u8>>,
+    payload: Option<Vec<u8>>,
 ) -> Flow {
     Flow::new("tcp-client")
         .role(Role::Initiator)
         .state(client_syn_sent_state(local_ip, remote_ip, remote_port))
-        .state(stub_state(ESTABLISHED, FIN_WAIT_1))
+        .state(client_established_state(
+            local_ip,
+            remote_ip,
+            remote_port,
+            payload,
+        ))
         .state(stub_state(FIN_WAIT_1, FIN_WAIT_2))
         .state(stub_state(FIN_WAIT_2, CLOSED))
         .state(terminal_state(CLOSED))
@@ -300,6 +305,35 @@ fn client_syn_ack_transition(
         },
     )
     .targets([ESTABLISHED])
+}
+
+fn client_established_state(
+    local_ip: Ipv4Addr,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
+    payload: Option<Vec<u8>>,
+) -> FlowState {
+    FlowState::new(ESTABLISHED)
+        .on_entry(move |ctx| {
+            let Some(payload) = payload.as_deref() else {
+                return Ok(Step::goto(FIN_WAIT_1));
+            };
+
+            let data = data_segment(
+                ctx,
+                local_ip,
+                TCP_CLIENT_LOCAL_PORT,
+                remote_ip,
+                remote_port,
+                payload,
+            );
+            let snd_nxt = tcp_snd_nxt(ctx).wrapping_add(payload.len() as u32);
+            ctx.set_tcp_snd_nxt(snd_nxt);
+
+            Ok(Step::send(data))
+        })
+        .entry_description("TCP PSH-ACK data")
+        .entry_targets([FIN_WAIT_1])
 }
 
 fn stub_state(name: &'static str, next: &'static str) -> FlowState {
@@ -494,6 +528,47 @@ mod tests {
         assert_eq!(tcp.acknowledgment_number_value(), PEER_ISS.wrapping_add(1));
         assert_eq!(tcp.flags_value(), TCP_FLAG_ACK);
         assert_eq!(step.target(), Some(ESTABLISHED));
+    }
+
+    #[test]
+    fn tcp_client_established_entry_sends_payload_and_advances_snd_nxt() {
+        let payload = b"hello over tcp".to_vec();
+        let mut flow = client_flow(
+            local_ipv4(),
+            remote_ipv4(),
+            REMOTE_PORT,
+            Some(payload.clone()),
+        );
+        let mut context = tcp_context();
+
+        let step = flow
+            .state_mut(ESTABLISHED)
+            .expect("Established state exists")
+            .run_entry(&mut context)
+            .expect("Established entry should run")
+            .expect("Established entry should return a step");
+        let packet = step
+            .outgoing()
+            .expect("Established entry sends payload data");
+        let decoded = compiled_ipv4(packet.clone());
+        let ipv4 = decoded.layer::<crafter::Ipv4>().expect("IPv4 layer");
+        let tcp = decoded.layer::<crafter::Tcp>().expect("TCP layer");
+        let raw = decoded.layer::<crafter::Raw>().expect("Raw payload");
+
+        assert_eq!(step.target(), None);
+        assert!(step.expects_reply());
+        assert_eq!(ipv4.source(), local_ipv4());
+        assert_eq!(ipv4.destination(), remote_ipv4());
+        assert_eq!(tcp.source_port_value(), TCP_CLIENT_LOCAL_PORT);
+        assert_eq!(tcp.destination_port_value(), REMOTE_PORT);
+        assert_eq!(tcp.sequence_number_value(), SND_NXT);
+        assert_eq!(tcp.acknowledgment_number_value(), RCV_NXT);
+        assert_eq!(tcp.flags_value(), TCP_FLAG_PSH | TCP_FLAG_ACK);
+        assert_eq!(raw.as_bytes(), payload.as_slice());
+        assert_eq!(
+            context.get_tcp_snd_nxt(),
+            Some(SND_NXT.wrapping_add(payload.len() as u32))
+        );
     }
 
     fn assert_named_states(flow: &crate::Flow, expected: &[&str]) {

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -1,0 +1,130 @@
+//! TCP flow templates.
+//!
+//! The client lifecycle is `SynSent -> Established -> FinWait1 -> FinWait2 ->
+//! Closed`.
+//! The server lifecycle is `Listen -> SynReceived -> Established -> CloseWait ->
+//! LastAck -> Closed`.
+
+use std::net::Ipv4Addr;
+
+use crate::{Flow, FlowBuilderExt, FlowState, Role, Step};
+
+/// Initial client state: active open has sent or will send SYN.
+pub const SYN_SENT: &str = "SynSent";
+/// Shared connected state after the three-way handshake completes.
+pub const ESTABLISHED: &str = "Established";
+/// Client active-close state after sending FIN and awaiting its ACK.
+pub const FIN_WAIT_1: &str = "FinWait1";
+/// Client active-close state after peer ACKs the FIN and before peer FIN.
+pub const FIN_WAIT_2: &str = "FinWait2";
+/// Terminal client state after graceful close completes.
+pub const CLOSED: &str = "Closed";
+/// Initial server state: passive open is waiting for SYN.
+pub const LISTEN: &str = "Listen";
+/// Server state after receiving SYN and sending SYN-ACK.
+pub const SYN_RECEIVED: &str = "SynReceived";
+/// Server passive-close state after receiving peer FIN.
+pub const CLOSE_WAIT: &str = "CloseWait";
+/// Server passive-close state after sending FIN and awaiting its ACK.
+pub const LAST_ACK: &str = "LastAck";
+/// Terminal server state after graceful close completes.
+pub const CLOSED_SRV: &str = "ClosedSrv";
+
+/// Build the TCP client flow scaffold.
+///
+/// The address, port, and payload arguments are placeholders for the real TCP
+/// actions added by later steps. This scaffold only declares the lifecycle.
+pub fn client_flow(
+    _local_ip: Ipv4Addr,
+    _remote_ip: Ipv4Addr,
+    _remote_port: u16,
+    _payload: Option<Vec<u8>>,
+) -> Flow {
+    Flow::new("tcp-client")
+        .role(Role::Initiator)
+        .state(stub_state(SYN_SENT, ESTABLISHED))
+        .state(stub_state(ESTABLISHED, FIN_WAIT_1))
+        .state(stub_state(FIN_WAIT_1, FIN_WAIT_2))
+        .state(stub_state(FIN_WAIT_2, CLOSED))
+        .state(terminal_state(CLOSED))
+        .initial(SYN_SENT)
+}
+
+/// Build the TCP server flow scaffold.
+///
+/// The address and port arguments are placeholders for the real TCP actions
+/// added by later steps. This scaffold only declares the lifecycle.
+pub fn server_flow(_local_ip: Ipv4Addr, _listen_port: u16) -> Flow {
+    Flow::new("tcp-server")
+        .role(Role::Responder)
+        .state(stub_state(LISTEN, SYN_RECEIVED))
+        .state(stub_state(SYN_RECEIVED, ESTABLISHED))
+        .state(stub_state(ESTABLISHED, CLOSE_WAIT))
+        .state(stub_state(CLOSE_WAIT, LAST_ACK))
+        .state(stub_state(LAST_ACK, CLOSED_SRV))
+        .state(terminal_state(CLOSED_SRV))
+        .initial(LISTEN)
+}
+
+fn stub_state(name: &'static str, next: &'static str) -> FlowState {
+    FlowState::new(name)
+        .on_entry(move |_ctx| Ok(Step::goto(next)))
+        .entry_description("TCP scaffold placeholder")
+        .entry_targets([next])
+}
+
+fn terminal_state(name: &'static str) -> FlowState {
+    FlowState::new(name)
+        .on_entry(|_ctx| Ok(Step::done()))
+        .entry_terminal()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        client_flow, server_flow, CLOSED, CLOSED_SRV, CLOSE_WAIT, ESTABLISHED, FIN_WAIT_1,
+        FIN_WAIT_2, LAST_ACK, LISTEN, SYN_RECEIVED, SYN_SENT,
+    };
+    use crate::{docaddr, Role};
+
+    #[test]
+    fn tcp_client_flow_exposes_initial_and_named_states() {
+        let flow = client_flow(
+            docaddr::CLIENT_IPV4,
+            docaddr::SERVER_IPV4,
+            80,
+            Some(b"hello".to_vec()),
+        );
+
+        assert_eq!(flow.role(), Role::Initiator);
+        assert_eq!(flow.initial(), SYN_SENT);
+        assert_named_states(&flow, &[SYN_SENT, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, CLOSED]);
+        flow.validate().expect("TCP client scaffold is valid");
+    }
+
+    #[test]
+    fn tcp_server_flow_exposes_initial_and_named_states() {
+        let flow = server_flow(docaddr::SERVER_IPV4, 80);
+
+        assert_eq!(flow.role(), Role::Responder);
+        assert_eq!(flow.initial(), LISTEN);
+        assert_named_states(
+            &flow,
+            &[
+                LISTEN,
+                SYN_RECEIVED,
+                ESTABLISHED,
+                CLOSE_WAIT,
+                LAST_ACK,
+                CLOSED_SRV,
+            ],
+        );
+        flow.validate().expect("TCP server scaffold is valid");
+    }
+
+    fn assert_named_states(flow: &crate::Flow, expected: &[&str]) {
+        for name in expected {
+            assert!(flow.state(name).is_some(), "missing {name} state");
+        }
+    }
+}

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -36,7 +36,7 @@ pub const CLOSE_WAIT: &str = "CloseWait";
 /// Server passive-close state after sending FIN and awaiting its ACK.
 pub const LAST_ACK: &str = "LastAck";
 /// Terminal server state after graceful close completes.
-pub const CLOSED_SRV: &str = "ClosedSrv";
+pub const CLOSED_SRV: &str = CLOSED;
 
 fn syn_segment(
     ctx: &PacketContext,
@@ -232,15 +232,19 @@ pub fn client_flow(
 /// The address and port arguments are placeholders for the real TCP actions
 /// added by later steps. This scaffold only declares the lifecycle.
 pub fn server_flow(_local_ip: Ipv4Addr, _listen_port: u16) -> Flow {
-    Flow::new("tcp-server")
+    let flow = Flow::new("tcp-server")
         .role(Role::Responder)
-        .state(stub_state(LISTEN, SYN_RECEIVED))
+        .state(server_listen_state())
         .state(stub_state(SYN_RECEIVED, ESTABLISHED))
         .state(stub_state(ESTABLISHED, CLOSE_WAIT))
         .state(stub_state(CLOSE_WAIT, LAST_ACK))
-        .state(stub_state(LAST_ACK, CLOSED_SRV))
-        .state(terminal_state(CLOSED_SRV))
-        .initial(LISTEN)
+        .state(stub_state(LAST_ACK, CLOSED))
+        .state(terminal_state(CLOSED))
+        .initial(LISTEN);
+
+    flow.validate()
+        .expect("TCP server flow shape should validate");
+    flow
 }
 
 fn client_syn_sent_state(local_ip: Ipv4Addr, remote_ip: Ipv4Addr, remote_port: u16) -> FlowState {
@@ -554,6 +558,10 @@ fn acknowledge_peer_fin(packet: &crafter::Packet, ctx: &mut PacketContext) {
     ctx.set_tcp_rcv_nxt(tcp.sequence_number_value().wrapping_add(1));
 }
 
+fn server_listen_state() -> FlowState {
+    FlowState::new(LISTEN)
+}
+
 fn stub_state(name: &'static str, next: &'static str) -> FlowState {
     FlowState::new(name)
         .on_entry(move |_ctx| Ok(Step::goto(next)))
@@ -606,8 +614,8 @@ fn tcp_rcv_nxt(ctx: &PacketContext) -> u32 {
 mod tests {
     use super::{
         ack_segment, client_flow, data_segment, fin_segment, server_flow, syn_ack_segment,
-        syn_segment, CLOSED, CLOSED_SRV, CLOSE_WAIT, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, LAST_ACK,
-        LISTEN, SYN_RECEIVED, SYN_SENT, TCP_CLIENT_ISS, TCP_CLIENT_LOCAL_PORT, TCP_MSS, TCP_WINDOW,
+        syn_segment, CLOSED, CLOSE_WAIT, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, LAST_ACK, LISTEN,
+        SYN_RECEIVED, SYN_SENT, TCP_CLIENT_ISS, TCP_CLIENT_LOCAL_PORT, TCP_MSS, TCP_WINDOW,
     };
     use std::net::Ipv4Addr;
 
@@ -671,14 +679,13 @@ mod tests {
         assert_eq!(flow.initial(), LISTEN);
         assert_named_states(
             &flow,
-            &[
-                LISTEN,
-                SYN_RECEIVED,
-                ESTABLISHED,
-                CLOSE_WAIT,
-                LAST_ACK,
-                CLOSED_SRV,
-            ],
+            &[LISTEN, SYN_RECEIVED, ESTABLISHED, CLOSE_WAIT, LAST_ACK, CLOSED],
+        );
+        let listen = flow.state(LISTEN).expect("Listen state exists");
+        assert!(!listen.has_entry(), "Listen must not send on entry");
+        assert!(
+            listen.transitions().is_empty(),
+            "SYN transition is added in the next step"
         );
         flow.validate().expect("TCP server scaffold is valid");
     }

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -594,7 +594,7 @@ fn server_final_ack_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transiti
 
 fn server_final_ack_matcher(local_ip: Ipv4Addr, listen_port: u16) -> impl crate::Matcher {
     predicate(
-        "tcp final ACK for stored four-tuple and seq == tcp_rcv_nxt",
+        "tcp final ACK for stored four-tuple and seq == tcp_rcv_nxt (ACK)",
         move |packet, ctx| {
             let Some(remote_ip) = ctx.get_tcp_remote_ipv4() else {
                 return false;
@@ -726,30 +726,33 @@ fn server_fin_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
 }
 
 fn server_fin_matcher(local_ip: Ipv4Addr, listen_port: u16) -> impl crate::Matcher {
-    predicate("tcp server FIN seq == tcp_rcv_nxt", move |packet, ctx| {
-        let Some(remote_ip) = ctx.get_tcp_remote_ipv4() else {
-            return false;
-        };
-        let Some(remote_port) = ctx.get_tcp_remote_port() else {
-            return false;
-        };
+    predicate(
+        "tcp server FIN seq == tcp_rcv_nxt (FIN|ACK)",
+        move |packet, ctx| {
+            let Some(remote_ip) = ctx.get_tcp_remote_ipv4() else {
+                return false;
+            };
+            let Some(remote_port) = ctx.get_tcp_remote_port() else {
+                return false;
+            };
 
-        let matcher = tcp_segment_for_ipv4(
-            local_ip,
-            listen_port,
-            remote_ip,
-            remote_port,
-            crafter::TCP_FLAG_FIN | crafter::TCP_FLAG_ACK,
-        )
-        .ack_matches_tcp_snd_nxt();
-        if !matcher.matches(packet, ctx) {
-            return false;
-        }
+            let matcher = tcp_segment_for_ipv4(
+                local_ip,
+                listen_port,
+                remote_ip,
+                remote_port,
+                crafter::TCP_FLAG_FIN | crafter::TCP_FLAG_ACK,
+            )
+            .ack_matches_tcp_snd_nxt();
+            if !matcher.matches(packet, ctx) {
+                return false;
+            }
 
-        packet
-            .layer::<crafter::Tcp>()
-            .is_some_and(|tcp| ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value()))
-    })
+            packet
+                .layer::<crafter::Tcp>()
+                .is_some_and(|tcp| ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value()))
+        },
+    )
 }
 
 fn acknowledge_server_peer_fin(packet: &crafter::Packet, ctx: &mut PacketContext) {
@@ -806,7 +809,7 @@ fn server_last_ack_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transitio
 
 fn server_last_ack_matcher(local_ip: Ipv4Addr, listen_port: u16) -> impl crate::Matcher {
     predicate(
-        "tcp server final ACK seq == tcp_rcv_nxt and ack == tcp_snd_nxt",
+        "tcp server final ACK seq == tcp_rcv_nxt and ack == tcp_snd_nxt (ACK)",
         move |packet, ctx| {
             let Some(remote_ip) = ctx.get_tcp_remote_ipv4() else {
                 return false;
@@ -938,6 +941,7 @@ mod tests {
         for expected in [
             "TCP SYN",
             "flags include 0x012",
+            "(SYN|ACK)",
             "-> Established",
             "TCP PSH-ACK data",
             "tcp data seq == tcp_rcv_nxt",
@@ -945,6 +949,7 @@ mod tests {
             "TCP FIN-ACK active close",
             "-> FinWait2",
             "tcp FIN seq == tcp_rcv_nxt",
+            "(FIN|ACK)",
             "-> Closed [terminal]",
         ] {
             assert!(
@@ -990,9 +995,11 @@ mod tests {
             "tcp SYN to listen port",
             "-> SynReceived",
             "tcp final ACK for stored four-tuple",
+            "(ACK)",
             "-> Established",
             "tcp server data seq == tcp_rcv_nxt",
             "tcp server FIN seq == tcp_rcv_nxt",
+            "(FIN|ACK)",
             "-> CloseWait",
             "TCP FIN-ACK passive close",
             "-> LastAck",

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -239,8 +239,8 @@ pub fn server_flow(local_ip: Ipv4Addr, listen_port: u16, response: Option<Vec<u8
         .state(server_listen_state(local_ip, listen_port))
         .state(server_syn_received_state(local_ip, listen_port))
         .state(server_established_state(local_ip, listen_port, response))
-        .state(stub_state(CLOSE_WAIT, LAST_ACK))
-        .state(stub_state(LAST_ACK, CLOSED))
+        .state(server_close_wait_state(local_ip, listen_port))
+        .state(server_last_ack_state(local_ip, listen_port))
         .state(terminal_state(CLOSED))
         .initial(LISTEN);
 
@@ -573,7 +573,9 @@ fn server_established_state(
     listen_port: u16,
     response: Option<Vec<u8>>,
 ) -> FlowState {
-    FlowState::new(ESTABLISHED).on(server_data_transition(local_ip, listen_port, response))
+    FlowState::new(ESTABLISHED)
+        .on(server_data_transition(local_ip, listen_port, response))
+        .on(server_fin_transition(local_ip, listen_port))
 }
 
 fn server_syn_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
@@ -726,17 +728,142 @@ fn server_data_matcher(local_ip: Ipv4Addr, listen_port: u16) -> impl crate::Matc
                 return false;
             };
 
-            !raw.as_bytes().is_empty()
+            !tcp.has_fin()
+                && !raw.as_bytes().is_empty()
                 && ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value())
         },
     )
 }
 
-fn stub_state(name: &'static str, next: &'static str) -> FlowState {
-    FlowState::new(name)
-        .on_entry(move |_ctx| Ok(Step::goto(next)))
-        .entry_description("TCP scaffold placeholder")
-        .entry_targets([next])
+fn server_fin_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
+    Transition::on(server_fin_matcher(local_ip, listen_port), move |packet, ctx| {
+        acknowledge_server_peer_fin(packet, ctx);
+
+        let remote_ip = ctx.get_tcp_remote_ipv4().ok_or_else(|| {
+            FlowError::Capture("matched TCP server FIN packet has no remote IPv4".to_string())
+        })?;
+        let remote_port = ctx.get_tcp_remote_port().ok_or_else(|| {
+            FlowError::Capture("matched TCP server FIN packet has no remote port".to_string())
+        })?;
+        let ack = ack_segment(ctx, local_ip, listen_port, remote_ip, remote_port);
+
+        Ok(Step::send(ack).goto(CLOSE_WAIT))
+    })
+    .targets([CLOSE_WAIT])
+}
+
+fn server_fin_matcher(local_ip: Ipv4Addr, listen_port: u16) -> impl crate::Matcher {
+    predicate(
+        "tcp server FIN seq == tcp_rcv_nxt",
+        move |packet, ctx| {
+            let Some(remote_ip) = ctx.get_tcp_remote_ipv4() else {
+                return false;
+            };
+            let Some(remote_port) = ctx.get_tcp_remote_port() else {
+                return false;
+            };
+
+            let matcher = tcp_segment_for_ipv4(
+                local_ip,
+                listen_port,
+                remote_ip,
+                remote_port,
+                crafter::TCP_FLAG_FIN | crafter::TCP_FLAG_ACK,
+            )
+            .ack_matches_tcp_snd_nxt();
+            if !matcher.matches(packet, ctx) {
+                return false;
+            }
+
+            packet.layer::<crafter::Tcp>().is_some_and(|tcp| {
+                ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value())
+            })
+        },
+    )
+}
+
+fn acknowledge_server_peer_fin(packet: &crafter::Packet, ctx: &mut PacketContext) {
+    let tcp = packet
+        .layer::<crafter::Tcp>()
+        .expect("matched TCP server FIN packet has no TCP layer");
+    let payload_len = packet
+        .layer::<crafter::Raw>()
+        .map(|raw| {
+            let payload = raw.as_bytes();
+            if !payload.is_empty() {
+                ctx.append_tcp_payload(payload);
+            }
+            payload.len() as u32
+        })
+        .unwrap_or(0);
+    ctx.set_tcp_rcv_nxt(
+        tcp.sequence_number_value()
+            .wrapping_add(payload_len)
+            .wrapping_add(1),
+    );
+}
+
+fn server_close_wait_state(local_ip: Ipv4Addr, listen_port: u16) -> FlowState {
+    FlowState::new(CLOSE_WAIT)
+        .on_entry(move |ctx| {
+            let remote_ip = ctx.get_tcp_remote_ipv4().ok_or_else(|| {
+                FlowError::Capture("TCP CloseWait entry requires remote IPv4".to_string())
+            })?;
+            let remote_port = ctx.get_tcp_remote_port().ok_or_else(|| {
+                FlowError::Capture("TCP CloseWait entry requires remote port".to_string())
+            })?;
+            let fin = fin_segment(ctx, local_ip, listen_port, remote_ip, remote_port);
+            let snd_nxt = tcp_snd_nxt(ctx).wrapping_add(1);
+            ctx.set_tcp_snd_nxt(snd_nxt);
+
+            Ok(Step::send(fin).goto(LAST_ACK))
+        })
+        .entry_description("TCP FIN-ACK passive close")
+        .entry_targets([LAST_ACK])
+}
+
+fn server_last_ack_state(local_ip: Ipv4Addr, listen_port: u16) -> FlowState {
+    FlowState::new(LAST_ACK).on(server_last_ack_transition(local_ip, listen_port))
+}
+
+fn server_last_ack_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
+    Transition::on(server_last_ack_matcher(local_ip, listen_port), |_packet, _ctx| {
+        Ok(Step::goto(CLOSED))
+    })
+    .targets([CLOSED])
+}
+
+fn server_last_ack_matcher(local_ip: Ipv4Addr, listen_port: u16) -> impl crate::Matcher {
+    predicate(
+        "tcp server final ACK seq == tcp_rcv_nxt and ack == tcp_snd_nxt",
+        move |packet, ctx| {
+            let Some(remote_ip) = ctx.get_tcp_remote_ipv4() else {
+                return false;
+            };
+            let Some(remote_port) = ctx.get_tcp_remote_port() else {
+                return false;
+            };
+
+            let matcher = tcp_segment_for_ipv4(
+                local_ip,
+                listen_port,
+                remote_ip,
+                remote_port,
+                crafter::TCP_FLAG_ACK,
+            )
+            .ack_matches_tcp_snd_nxt();
+            if !matcher.matches(packet, ctx) {
+                return false;
+            }
+
+            packet.layer::<crafter::Tcp>().is_some_and(|tcp| {
+                !tcp.has_fin()
+                    && !tcp.has_flag(crafter::TCP_FLAG_RST)
+                    && packet.layer::<crafter::Raw>().is_none()
+                    && ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value())
+            })
+        },
+    )
 }
 
 fn terminal_state(name: &'static str) -> FlowState {
@@ -1105,6 +1232,149 @@ mod tests {
         assert_eq!(raw.as_bytes(), response.as_slice());
         assert_eq!(step.target(), None);
         assert!(step.expects_reply());
+    }
+
+    #[test]
+    fn tcp_server_established_fin_transition_sends_ack_and_reaches_close_wait() {
+        const CLIENT_PORT: u16 = 49_153;
+        const LISTEN_PORT: u16 = 8080;
+
+        let final_payload = b"client final bytes";
+        let mut flow = server_flow(local_ipv4(), LISTEN_PORT, None);
+        let mut context = tcp_context();
+        context.set_tcp_local_port(LISTEN_PORT);
+        context.set_tcp_remote_port(CLIENT_PORT);
+        context.set_tcp_remote_ipv4(remote_ipv4());
+
+        let client_fin =
+            fin_data_ack_to_server(RCV_NXT, SND_NXT, CLIENT_PORT, LISTEN_PORT, final_payload);
+        let wrong_seq = fin_ack_to_server(
+            RCV_NXT.wrapping_add(1),
+            SND_NXT,
+            CLIENT_PORT,
+            LISTEN_PORT,
+        );
+
+        {
+            let established = flow.state(ESTABLISHED).expect("Established state exists");
+            assert!(
+                !established.transitions()[0].matches(&client_fin, &context),
+                "data transition must not steal FIN segments carrying payload"
+            );
+            let transition = &established.transitions()[1];
+            assert!(transition.matches(&client_fin, &context));
+            assert!(
+                !transition.matches(&wrong_seq, &context),
+                "FIN transition must reject unexpected client sequence"
+            );
+        }
+
+        let step = flow
+            .state_mut(ESTABLISHED)
+            .expect("Established state exists")
+            .find_transition(&client_fin, &context)
+            .expect("client FIN transition matches")
+            .fire(&client_fin, &mut context)
+            .expect("client FIN transition should fire");
+        let ack = step.outgoing().expect("client FIN transition sends ACK");
+        let tcp = ack.layer::<crafter::Tcp>().expect("TCP layer");
+        let expected_rcv_nxt = RCV_NXT
+            .wrapping_add(final_payload.len() as u32)
+            .wrapping_add(1);
+
+        assert_eq!(context.tcp_received_payload(), final_payload);
+        assert_eq!(context.get_tcp_rcv_nxt(), Some(expected_rcv_nxt));
+        assert_eq!(tcp.source_port_value(), LISTEN_PORT);
+        assert_eq!(tcp.destination_port_value(), CLIENT_PORT);
+        assert_eq!(tcp.sequence_number_value(), SND_NXT);
+        assert_eq!(tcp.acknowledgment_number_value(), expected_rcv_nxt);
+        assert_eq!(tcp.flags_value(), TCP_FLAG_ACK);
+        assert_eq!(step.target(), Some(CLOSE_WAIT));
+    }
+
+    #[test]
+    fn tcp_server_close_wait_entry_sends_fin_and_advances_snd_nxt() {
+        const CLIENT_PORT: u16 = 49_153;
+        const LISTEN_PORT: u16 = 8080;
+
+        let mut flow = server_flow(local_ipv4(), LISTEN_PORT, None);
+        let mut context = tcp_context();
+        context.set_tcp_local_port(LISTEN_PORT);
+        context.set_tcp_remote_port(CLIENT_PORT);
+        context.set_tcp_remote_ipv4(remote_ipv4());
+
+        let step = flow
+            .state_mut(CLOSE_WAIT)
+            .expect("CloseWait state exists")
+            .run_entry(&mut context)
+            .expect("CloseWait entry should run")
+            .expect("CloseWait entry should return a step");
+        let fin = step.outgoing().expect("CloseWait entry sends FIN");
+        let tcp = fin.layer::<crafter::Tcp>().expect("TCP layer");
+
+        assert_eq!(step.target(), Some(LAST_ACK));
+        assert!(step.expects_reply());
+        assert_eq!(tcp.source_port_value(), LISTEN_PORT);
+        assert_eq!(tcp.destination_port_value(), CLIENT_PORT);
+        assert_eq!(tcp.sequence_number_value(), SND_NXT);
+        assert_eq!(tcp.acknowledgment_number_value(), RCV_NXT);
+        assert_eq!(tcp.flags_value(), TCP_FLAG_FIN | TCP_FLAG_ACK);
+        assert_eq!(context.get_tcp_snd_nxt(), Some(SND_NXT.wrapping_add(1)));
+    }
+
+    #[test]
+    fn tcp_server_last_ack_transition_accepts_final_ack_and_reaches_closed() {
+        const CLIENT_PORT: u16 = 49_153;
+        const LISTEN_PORT: u16 = 8080;
+
+        let mut flow = server_flow(local_ipv4(), LISTEN_PORT, None);
+        let mut context = tcp_context();
+        context.set_tcp_snd_nxt(SND_NXT.wrapping_add(1));
+        context.set_tcp_local_port(LISTEN_PORT);
+        context.set_tcp_remote_port(CLIENT_PORT);
+        context.set_tcp_remote_ipv4(remote_ipv4());
+
+        let final_ack = ack_to_server(
+            RCV_NXT,
+            SND_NXT.wrapping_add(1),
+            CLIENT_PORT,
+            LISTEN_PORT,
+        );
+        let wrong_ack = ack_to_server(RCV_NXT, SND_NXT, CLIENT_PORT, LISTEN_PORT);
+        let late_data = data_to_server(
+            RCV_NXT,
+            SND_NXT.wrapping_add(1),
+            CLIENT_PORT,
+            LISTEN_PORT,
+            b"late data",
+        );
+
+        {
+            let last_ack = flow.state(LAST_ACK).expect("LastAck state exists");
+            let transition = &last_ack.transitions()[0];
+            assert!(transition.matches(&final_ack, &context));
+            assert!(
+                !transition.matches(&wrong_ack, &context),
+                "LastAck transition must reject ACKs that do not acknowledge server FIN"
+            );
+            assert!(
+                !transition.matches(&late_data, &context),
+                "LastAck transition must reject payload-carrying ACKs"
+            );
+        }
+
+        let step = flow
+            .state_mut(LAST_ACK)
+            .expect("LastAck state exists")
+            .find_transition(&final_ack, &context)
+            .expect("final ACK transition matches")
+            .fire(&final_ack, &mut context)
+            .expect("final ACK transition should fire");
+
+        assert!(step.outgoing().is_none());
+        assert_eq!(step.target(), Some(CLOSED));
+        assert_eq!(context.get_tcp_snd_nxt(), Some(SND_NXT.wrapping_add(1)));
+        assert_eq!(context.get_tcp_rcv_nxt(), Some(RCV_NXT));
     }
 
     #[test]
@@ -1610,6 +1880,50 @@ mod tests {
             .ack(ack)
             .window(TCP_WINDOW)
             .ack_segment()
+            .psh();
+
+        compiled_ipv4(
+            crafter::Ipv4::new()
+                .src(remote_ipv4())
+                .dst(local_ipv4())
+                .protocol(crafter::IPPROTO_TCP)
+                / tcp
+                / crafter::Raw::from_bytes(payload),
+        )
+    }
+
+    fn fin_ack_to_server(client_seq: u32, ack: u32, client_port: u16, listen_port: u16) -> Packet {
+        let tcp = crafter::Tcp::new()
+            .sport(client_port)
+            .dport(listen_port)
+            .seq(client_seq)
+            .ack(ack)
+            .window(TCP_WINDOW)
+            .fin_ack_segment();
+
+        compiled_ipv4(
+            crafter::Ipv4::new()
+                .src(remote_ipv4())
+                .dst(local_ipv4())
+                .protocol(crafter::IPPROTO_TCP)
+                / tcp,
+        )
+    }
+
+    fn fin_data_ack_to_server(
+        client_seq: u32,
+        ack: u32,
+        client_port: u16,
+        listen_port: u16,
+        payload: impl AsRef<[u8]>,
+    ) -> Packet {
+        let tcp = crafter::Tcp::new()
+            .sport(client_port)
+            .dport(listen_port)
+            .seq(client_seq)
+            .ack(ack)
+            .window(TCP_WINDOW)
+            .fin_ack_segment()
             .psh();
 
         compiled_ipv4(

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -81,7 +81,10 @@ mod api_check {
             Tcp::new().syn_ack_segment().flags_value(),
             TCP_FLAG_SYN | TCP_FLAG_ACK
         );
-        assert_eq!(Tcp::new().fin_ack_segment().flags_value(), TCP_FLAG_FIN | TCP_FLAG_ACK);
+        assert_eq!(
+            Tcp::new().fin_ack_segment().flags_value(),
+            TCP_FLAG_FIN | TCP_FLAG_ACK
+        );
 
         let tcp = Tcp::new()
             .sport(LOCAL_PORT)
@@ -260,13 +263,7 @@ fn client_syn_sent_state(local_ip: Ipv4Addr, remote_ip: Ipv4Addr, remote_port: u
             ctx.set_tcp_remote_port(remote_port);
             ctx.set_tcp_remote_ipv4(remote_ip);
 
-            let syn = syn_segment(
-                ctx,
-                local_ip,
-                TCP_CLIENT_LOCAL_PORT,
-                remote_ip,
-                remote_port,
-            );
+            let syn = syn_segment(ctx, local_ip, TCP_CLIENT_LOCAL_PORT, remote_ip, remote_port);
 
             Ok(Step::send(syn))
         })
@@ -304,13 +301,7 @@ fn client_syn_ack_transition(
             }
             ctx.set_tcp_peer_window(tcp.window_value());
 
-            let ack = ack_segment(
-                ctx,
-                local_ip,
-                TCP_CLIENT_LOCAL_PORT,
-                remote_ip,
-                remote_port,
-            );
+            let ack = ack_segment(ctx, local_ip, TCP_CLIENT_LOCAL_PORT, remote_ip, remote_port);
 
             Ok(Step::send(ack).goto(ESTABLISHED))
         },
@@ -329,6 +320,10 @@ fn client_established_state(
             let Some(payload) = payload.as_deref() else {
                 return Ok(Step::goto(FIN_WAIT_1));
             };
+            let payload = outbound_payload_segment(ctx, payload);
+            if payload.is_empty() {
+                return Ok(Step::goto(FIN_WAIT_1));
+            }
 
             let data = data_segment(
                 ctx,
@@ -349,11 +344,7 @@ fn client_established_state(
         .on(client_rst_transition(local_ip, remote_ip, remote_port))
 }
 
-fn client_data_transition(
-    local_ip: Ipv4Addr,
-    remote_ip: Ipv4Addr,
-    remote_port: u16,
-) -> Transition {
+fn client_data_transition(local_ip: Ipv4Addr, remote_ip: Ipv4Addr, remote_port: u16) -> Transition {
     let matcher = tcp_segment_for_ipv4(
         local_ip,
         TCP_CLIENT_LOCAL_PORT,
@@ -372,8 +363,7 @@ fn client_data_transition(
                 return false;
             };
 
-            !raw.as_bytes().is_empty()
-                && ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value())
+            !raw.as_bytes().is_empty() && ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value())
         },
     ));
 
@@ -387,33 +377,17 @@ fn client_data_transition(
         ctx.append_tcp_payload(payload);
         ctx.set_tcp_rcv_nxt(rcv_nxt);
 
-        let ack = ack_segment(
-            ctx,
-            local_ip,
-            TCP_CLIENT_LOCAL_PORT,
-            remote_ip,
-            remote_port,
-        );
+        let ack = ack_segment(ctx, local_ip, TCP_CLIENT_LOCAL_PORT, remote_ip, remote_port);
 
         Ok(Step::send(ack).goto(FIN_WAIT_1))
     })
     .targets([FIN_WAIT_1])
 }
 
-fn client_fin_wait_1_state(
-    local_ip: Ipv4Addr,
-    remote_ip: Ipv4Addr,
-    remote_port: u16,
-) -> FlowState {
+fn client_fin_wait_1_state(local_ip: Ipv4Addr, remote_ip: Ipv4Addr, remote_port: u16) -> FlowState {
     FlowState::new(FIN_WAIT_1)
         .on_entry(move |ctx| {
-            let fin = fin_segment(
-                ctx,
-                local_ip,
-                TCP_CLIENT_LOCAL_PORT,
-                remote_ip,
-                remote_port,
-            );
+            let fin = fin_segment(ctx, local_ip, TCP_CLIENT_LOCAL_PORT, remote_ip, remote_port);
             let snd_nxt = tcp_snd_nxt(ctx).wrapping_add(1);
             ctx.set_tcp_snd_nxt(snd_nxt);
 
@@ -446,11 +420,14 @@ fn client_fin_wait_1_ack_transition(
         crafter::TCP_FLAG_ACK,
     )
     .ack_matches_tcp_snd_nxt()
-    .and(predicate("tcp ACK segment has no FIN or RST", |packet, _ctx| {
-        packet.layer::<crafter::Tcp>().is_some_and(|tcp| {
-            !tcp.has_fin() && !tcp.has_flag(crafter::TCP_FLAG_RST)
-        })
-    }));
+    .and(predicate(
+        "tcp ACK segment has no FIN or RST",
+        |packet, _ctx| {
+            packet
+                .layer::<crafter::Tcp>()
+                .is_some_and(|tcp| !tcp.has_fin() && !tcp.has_flag(crafter::TCP_FLAG_RST))
+        },
+    ));
 
     Transition::on(matcher, |_packet, _ctx| Ok(Step::goto(FIN_WAIT_2))).targets([FIN_WAIT_2])
 }
@@ -464,13 +441,7 @@ fn client_fin_wait_1_fin_transition(
         peer_fin_matcher(local_ip, remote_ip, remote_port),
         move |packet, ctx| {
             acknowledge_peer_fin(packet, ctx);
-            let ack = ack_segment(
-                ctx,
-                local_ip,
-                TCP_CLIENT_LOCAL_PORT,
-                remote_ip,
-                remote_port,
-            );
+            let ack = ack_segment(ctx, local_ip, TCP_CLIENT_LOCAL_PORT, remote_ip, remote_port);
 
             Ok(Step::send(ack).goto(CLOSED))
         },
@@ -478,24 +449,17 @@ fn client_fin_wait_1_fin_transition(
     .targets([CLOSED])
 }
 
-fn client_fin_wait_2_state(
-    local_ip: Ipv4Addr,
-    remote_ip: Ipv4Addr,
-    remote_port: u16,
-) -> FlowState {
-    FlowState::new(FIN_WAIT_2).on(client_fin_wait_2_fin_transition(
-        local_ip,
-        remote_ip,
-        remote_port,
-    ))
-    .on(client_rst_transition(local_ip, remote_ip, remote_port))
+fn client_fin_wait_2_state(local_ip: Ipv4Addr, remote_ip: Ipv4Addr, remote_port: u16) -> FlowState {
+    FlowState::new(FIN_WAIT_2)
+        .on(client_fin_wait_2_fin_transition(
+            local_ip,
+            remote_ip,
+            remote_port,
+        ))
+        .on(client_rst_transition(local_ip, remote_ip, remote_port))
 }
 
-fn client_rst_transition(
-    local_ip: Ipv4Addr,
-    remote_ip: Ipv4Addr,
-    remote_port: u16,
-) -> Transition {
+fn client_rst_transition(local_ip: Ipv4Addr, remote_ip: Ipv4Addr, remote_port: u16) -> Transition {
     Transition::on(
         tcp_segment_for_ipv4(
             local_ip,
@@ -519,13 +483,7 @@ fn client_fin_wait_2_fin_transition(
         peer_fin_matcher(local_ip, remote_ip, remote_port),
         move |packet, ctx| {
             acknowledge_peer_fin(packet, ctx);
-            let ack = ack_segment(
-                ctx,
-                local_ip,
-                TCP_CLIENT_LOCAL_PORT,
-                remote_ip,
-                remote_port,
-            );
+            let ack = ack_segment(ctx, local_ip, TCP_CLIENT_LOCAL_PORT, remote_ip, remote_port);
 
             Ok(Step::send(ack).goto(CLOSED))
         },
@@ -547,9 +505,9 @@ fn peer_fin_matcher(
     )
     .ack_matches_tcp_snd_nxt()
     .and(predicate("tcp FIN seq == tcp_rcv_nxt", |packet, ctx| {
-        packet.layer::<crafter::Tcp>().is_some_and(|tcp| {
-            ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value())
-        })
+        packet
+            .layer::<crafter::Tcp>()
+            .is_some_and(|tcp| ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value()))
     }))
 }
 
@@ -627,9 +585,10 @@ fn server_syn_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
 }
 
 fn server_final_ack_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
-    Transition::on(server_final_ack_matcher(local_ip, listen_port), |_packet, _ctx| {
-        Ok(Step::goto(ESTABLISHED))
-    })
+    Transition::on(
+        server_final_ack_matcher(local_ip, listen_port),
+        |_packet, _ctx| Ok(Step::goto(ESTABLISHED)),
+    )
     .targets([ESTABLISHED])
 }
 
@@ -656,9 +615,9 @@ fn server_final_ack_matcher(local_ip: Ipv4Addr, listen_port: u16) -> impl crate:
                 return false;
             }
 
-            packet.layer::<crafter::Tcp>().is_some_and(|tcp| {
-                ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value())
-            })
+            packet
+                .layer::<crafter::Tcp>()
+                .is_some_and(|tcp| ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value()))
         },
     )
 }
@@ -668,34 +627,45 @@ fn server_data_transition(
     listen_port: u16,
     response: Option<Vec<u8>>,
 ) -> Transition {
-    Transition::on(server_data_matcher(local_ip, listen_port), move |packet, ctx| {
-        let raw = packet.layer::<crafter::Raw>().ok_or_else(|| {
-            FlowError::Capture("matched TCP server data packet has no Raw payload".to_string())
-        })?;
-        let payload = raw.as_bytes();
-        let rcv_nxt = tcp_rcv_nxt(ctx).wrapping_add(payload.len() as u32);
+    Transition::on(
+        server_data_matcher(local_ip, listen_port),
+        move |packet, ctx| {
+            let raw = packet.layer::<crafter::Raw>().ok_or_else(|| {
+                FlowError::Capture("matched TCP server data packet has no Raw payload".to_string())
+            })?;
+            let payload = raw.as_bytes();
+            let rcv_nxt = tcp_rcv_nxt(ctx).wrapping_add(payload.len() as u32);
 
-        ctx.append_tcp_payload(payload);
-        ctx.set_tcp_rcv_nxt(rcv_nxt);
+            ctx.append_tcp_payload(payload);
+            ctx.set_tcp_rcv_nxt(rcv_nxt);
 
-        let remote_ip = ctx.get_tcp_remote_ipv4().ok_or_else(|| {
-            FlowError::Capture("matched TCP server data packet has no remote IPv4".to_string())
-        })?;
-        let remote_port = ctx.get_tcp_remote_port().ok_or_else(|| {
-            FlowError::Capture("matched TCP server data packet has no remote port".to_string())
-        })?;
-        if let Some(response) = response.as_deref() {
-            let data = data_segment(ctx, local_ip, listen_port, remote_ip, remote_port, response);
-            let snd_nxt = tcp_snd_nxt(ctx).wrapping_add(response.len() as u32);
-            ctx.set_tcp_snd_nxt(snd_nxt);
+            let remote_ip = ctx.get_tcp_remote_ipv4().ok_or_else(|| {
+                FlowError::Capture("matched TCP server data packet has no remote IPv4".to_string())
+            })?;
+            let remote_port = ctx.get_tcp_remote_port().ok_or_else(|| {
+                FlowError::Capture("matched TCP server data packet has no remote port".to_string())
+            })?;
+            if let Some(response) = response.as_deref() {
+                let response = outbound_payload_segment(ctx, response);
+                if response.is_empty() {
+                    let ack = ack_segment(ctx, local_ip, listen_port, remote_ip, remote_port);
 
-            return Ok(Step::send(data));
-        }
+                    return Ok(Step::send(ack));
+                }
 
-        let ack = ack_segment(ctx, local_ip, listen_port, remote_ip, remote_port);
+                let data =
+                    data_segment(ctx, local_ip, listen_port, remote_ip, remote_port, response);
+                let snd_nxt = tcp_snd_nxt(ctx).wrapping_add(response.len() as u32);
+                ctx.set_tcp_snd_nxt(snd_nxt);
 
-        Ok(Step::send(ack))
-    })
+                return Ok(Step::send(data));
+            }
+
+            let ack = ack_segment(ctx, local_ip, listen_port, remote_ip, remote_port);
+
+            Ok(Step::send(ack))
+        },
+    )
 }
 
 fn server_data_matcher(local_ip: Ipv4Addr, listen_port: u16) -> impl crate::Matcher {
@@ -736,50 +706,50 @@ fn server_data_matcher(local_ip: Ipv4Addr, listen_port: u16) -> impl crate::Matc
 }
 
 fn server_fin_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
-    Transition::on(server_fin_matcher(local_ip, listen_port), move |packet, ctx| {
-        acknowledge_server_peer_fin(packet, ctx);
+    Transition::on(
+        server_fin_matcher(local_ip, listen_port),
+        move |packet, ctx| {
+            acknowledge_server_peer_fin(packet, ctx);
 
-        let remote_ip = ctx.get_tcp_remote_ipv4().ok_or_else(|| {
-            FlowError::Capture("matched TCP server FIN packet has no remote IPv4".to_string())
-        })?;
-        let remote_port = ctx.get_tcp_remote_port().ok_or_else(|| {
-            FlowError::Capture("matched TCP server FIN packet has no remote port".to_string())
-        })?;
-        let ack = ack_segment(ctx, local_ip, listen_port, remote_ip, remote_port);
+            let remote_ip = ctx.get_tcp_remote_ipv4().ok_or_else(|| {
+                FlowError::Capture("matched TCP server FIN packet has no remote IPv4".to_string())
+            })?;
+            let remote_port = ctx.get_tcp_remote_port().ok_or_else(|| {
+                FlowError::Capture("matched TCP server FIN packet has no remote port".to_string())
+            })?;
+            let ack = ack_segment(ctx, local_ip, listen_port, remote_ip, remote_port);
 
-        Ok(Step::send(ack).goto(CLOSE_WAIT))
-    })
+            Ok(Step::send(ack).goto(CLOSE_WAIT))
+        },
+    )
     .targets([CLOSE_WAIT])
 }
 
 fn server_fin_matcher(local_ip: Ipv4Addr, listen_port: u16) -> impl crate::Matcher {
-    predicate(
-        "tcp server FIN seq == tcp_rcv_nxt",
-        move |packet, ctx| {
-            let Some(remote_ip) = ctx.get_tcp_remote_ipv4() else {
-                return false;
-            };
-            let Some(remote_port) = ctx.get_tcp_remote_port() else {
-                return false;
-            };
+    predicate("tcp server FIN seq == tcp_rcv_nxt", move |packet, ctx| {
+        let Some(remote_ip) = ctx.get_tcp_remote_ipv4() else {
+            return false;
+        };
+        let Some(remote_port) = ctx.get_tcp_remote_port() else {
+            return false;
+        };
 
-            let matcher = tcp_segment_for_ipv4(
-                local_ip,
-                listen_port,
-                remote_ip,
-                remote_port,
-                crafter::TCP_FLAG_FIN | crafter::TCP_FLAG_ACK,
-            )
-            .ack_matches_tcp_snd_nxt();
-            if !matcher.matches(packet, ctx) {
-                return false;
-            }
+        let matcher = tcp_segment_for_ipv4(
+            local_ip,
+            listen_port,
+            remote_ip,
+            remote_port,
+            crafter::TCP_FLAG_FIN | crafter::TCP_FLAG_ACK,
+        )
+        .ack_matches_tcp_snd_nxt();
+        if !matcher.matches(packet, ctx) {
+            return false;
+        }
 
-            packet.layer::<crafter::Tcp>().is_some_and(|tcp| {
-                ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value())
-            })
-        },
-    )
+        packet
+            .layer::<crafter::Tcp>()
+            .is_some_and(|tcp| ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value()))
+    })
 }
 
 fn acknowledge_server_peer_fin(packet: &crafter::Packet, ctx: &mut PacketContext) {
@@ -827,9 +797,10 @@ fn server_last_ack_state(local_ip: Ipv4Addr, listen_port: u16) -> FlowState {
 }
 
 fn server_last_ack_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
-    Transition::on(server_last_ack_matcher(local_ip, listen_port), |_packet, _ctx| {
-        Ok(Step::goto(CLOSED))
-    })
+    Transition::on(
+        server_last_ack_matcher(local_ip, listen_port),
+        |_packet, _ctx| Ok(Step::goto(CLOSED)),
+    )
     .targets([CLOSED])
 }
 
@@ -890,6 +861,20 @@ fn tcp_header(local_port: u16, remote_port: u16) -> crafter::Tcp {
 fn tcp_with_mss(tcp: crafter::Tcp) -> crafter::Tcp {
     tcp.tcp_option(crafter::TcpOption::maximum_segment_size(TCP_MSS))
         .expect("fixed TCP MSS option encodes")
+}
+
+fn outbound_payload_segment<'a>(ctx: &PacketContext, payload: &'a [u8]) -> &'a [u8] {
+    let peer_mss = ctx
+        .get_tcp_peer_mss()
+        .map(|mss| mss.min(TCP_MSS))
+        .unwrap_or(TCP_MSS) as usize;
+    let peer_window = ctx
+        .get_tcp_peer_window()
+        .map(usize::from)
+        .unwrap_or(usize::MAX);
+    let limit = payload.len().min(peer_mss).min(peer_window);
+
+    &payload[..limit]
 }
 
 fn tcp_iss(ctx: &PacketContext) -> u32 {
@@ -978,13 +963,27 @@ mod tests {
         assert!(flow.validate().is_ok());
         assert_named_states(
             &flow,
-            &[LISTEN, SYN_RECEIVED, ESTABLISHED, CLOSE_WAIT, LAST_ACK, CLOSED],
+            &[
+                LISTEN,
+                SYN_RECEIVED,
+                ESTABLISHED,
+                CLOSE_WAIT,
+                LAST_ACK,
+                CLOSED,
+            ],
         );
         let listen = flow.state(LISTEN).expect("Listen state exists");
         assert!(!listen.has_entry(), "Listen must not send on entry");
         assert_eq!(listen.transitions().len(), 1);
         let show = flow.show();
-        for expected in [LISTEN, SYN_RECEIVED, ESTABLISHED, CLOSE_WAIT, LAST_ACK, CLOSED] {
+        for expected in [
+            LISTEN,
+            SYN_RECEIVED,
+            ESTABLISHED,
+            CLOSE_WAIT,
+            LAST_ACK,
+            CLOSED,
+        ] {
             assert!(show.contains(expected), "show() missing state {expected}");
         }
         for expected in [
@@ -1050,10 +1049,7 @@ mod tests {
         assert_eq!(context.get_tcp_local_port(), Some(LISTEN_PORT));
         assert_eq!(context.get_tcp_remote_port(), Some(CLIENT_PORT));
         assert_eq!(context.get_tcp_remote_ipv4(), Some(remote_ipv4()));
-        assert_eq!(
-            context.get_tcp_rcv_nxt(),
-            Some(CLIENT_ISS.wrapping_add(1))
-        );
+        assert_eq!(context.get_tcp_rcv_nxt(), Some(CLIENT_ISS.wrapping_add(1)));
         assert_eq!(context.get_tcp_peer_mss(), Some(CLIENT_MSS));
         assert_eq!(context.get_tcp_peer_window(), Some(CLIENT_WINDOW));
         assert_eq!(context.get_tcp_iss(), Some(TCP_SERVER_ISS));
@@ -1071,6 +1067,7 @@ mod tests {
             CLIENT_ISS.wrapping_add(1)
         );
         assert_eq!(tcp.flags_value(), TCP_FLAG_SYN | TCP_FLAG_ACK);
+        assert_eq!(tcp.window_value(), TCP_WINDOW);
         assert_has_mss(tcp);
         assert_eq!(step.target(), Some(SYN_RECEIVED));
     }
@@ -1115,9 +1112,7 @@ mod tests {
         );
 
         {
-            let syn_received = flow
-                .state(SYN_RECEIVED)
-                .expect("SynReceived state exists");
+            let syn_received = flow.state(SYN_RECEIVED).expect("SynReceived state exists");
             let transition = &syn_received.transitions()[0];
             assert!(transition.matches(&final_ack, &context));
             assert!(
@@ -1248,6 +1243,43 @@ mod tests {
     }
 
     #[test]
+    fn tcp_server_established_response_is_limited_to_peer_mss() {
+        const CLIENT_PORT: u16 = 49_153;
+        const LISTEN_PORT: u16 = 8080;
+        const PEER_MSS: u16 = 6;
+
+        let request = b"client request";
+        let response = b"server response".to_vec();
+        let mut flow = server_flow(local_ipv4(), LISTEN_PORT, Some(response));
+        let mut context = tcp_context();
+        context.set_tcp_local_port(LISTEN_PORT);
+        context.set_tcp_remote_port(CLIENT_PORT);
+        context.set_tcp_remote_ipv4(remote_ipv4());
+        context.set_tcp_peer_mss(PEER_MSS);
+        context.set_tcp_peer_window(TCP_WINDOW);
+
+        let client_data = data_to_server(RCV_NXT, SND_NXT, CLIENT_PORT, LISTEN_PORT, request);
+        let step = flow
+            .state_mut(ESTABLISHED)
+            .expect("Established state exists")
+            .find_transition(&client_data, &context)
+            .expect("client data transition matches")
+            .fire(&client_data, &mut context)
+            .expect("client data transition should fire");
+        let packet = step
+            .outgoing()
+            .expect("client data transition sends configured response");
+        let decoded = compiled_ipv4(packet.clone());
+        let raw = decoded.layer::<crafter::Raw>().expect("Raw payload");
+
+        assert_eq!(raw.as_bytes(), b"server");
+        assert_eq!(
+            context.get_tcp_snd_nxt(),
+            Some(SND_NXT.wrapping_add(PEER_MSS as u32))
+        );
+    }
+
+    #[test]
     fn tcp_server_established_fin_transition_sends_ack_and_reaches_close_wait() {
         const CLIENT_PORT: u16 = 49_153;
         const LISTEN_PORT: u16 = 8080;
@@ -1261,12 +1293,8 @@ mod tests {
 
         let client_fin =
             fin_data_ack_to_server(RCV_NXT, SND_NXT, CLIENT_PORT, LISTEN_PORT, final_payload);
-        let wrong_seq = fin_ack_to_server(
-            RCV_NXT.wrapping_add(1),
-            SND_NXT,
-            CLIENT_PORT,
-            LISTEN_PORT,
-        );
+        let wrong_seq =
+            fin_ack_to_server(RCV_NXT.wrapping_add(1), SND_NXT, CLIENT_PORT, LISTEN_PORT);
 
         {
             let established = flow.state(ESTABLISHED).expect("Established state exists");
@@ -1347,12 +1375,7 @@ mod tests {
         context.set_tcp_remote_port(CLIENT_PORT);
         context.set_tcp_remote_ipv4(remote_ipv4());
 
-        let final_ack = ack_to_server(
-            RCV_NXT,
-            SND_NXT.wrapping_add(1),
-            CLIENT_PORT,
-            LISTEN_PORT,
-        );
+        let final_ack = ack_to_server(RCV_NXT, SND_NXT.wrapping_add(1), CLIENT_PORT, LISTEN_PORT);
         let wrong_ack = ack_to_server(RCV_NXT, SND_NXT, CLIENT_PORT, LISTEN_PORT);
         let late_data = data_to_server(
             RCV_NXT,
@@ -1413,6 +1436,7 @@ mod tests {
         assert_eq!(tcp.destination_port_value(), REMOTE_PORT);
         assert_eq!(tcp.sequence_number_value(), TCP_CLIENT_ISS);
         assert_eq!(tcp.flags_value(), TCP_FLAG_SYN);
+        assert_eq!(tcp.window_value(), TCP_WINDOW);
         assert_has_mss(tcp);
         assert_eq!(context.get_tcp_iss(), Some(TCP_CLIENT_ISS));
         assert_eq!(
@@ -1474,6 +1498,7 @@ mod tests {
         assert_eq!(tcp.sequence_number_value(), client_snd_nxt);
         assert_eq!(tcp.acknowledgment_number_value(), PEER_ISS.wrapping_add(1));
         assert_eq!(tcp.flags_value(), TCP_FLAG_ACK);
+        assert_eq!(tcp.window_value(), TCP_WINDOW);
         assert_eq!(step.target(), Some(ESTABLISHED));
     }
 
@@ -1515,6 +1540,35 @@ mod tests {
         assert_eq!(
             context.get_tcp_snd_nxt(),
             Some(SND_NXT.wrapping_add(payload.len() as u32))
+        );
+    }
+
+    #[test]
+    fn tcp_client_established_entry_limits_payload_to_peer_mss() {
+        const PEER_MSS: u16 = 5;
+
+        let payload = b"hello over tcp".to_vec();
+        let mut flow = client_flow(local_ipv4(), remote_ipv4(), REMOTE_PORT, Some(payload));
+        let mut context = tcp_context();
+        context.set_tcp_peer_mss(PEER_MSS);
+        context.set_tcp_peer_window(TCP_WINDOW);
+
+        let step = flow
+            .state_mut(ESTABLISHED)
+            .expect("Established state exists")
+            .run_entry(&mut context)
+            .expect("Established entry should run")
+            .expect("Established entry should return a step");
+        let packet = step
+            .outgoing()
+            .expect("Established entry sends payload data");
+        let decoded = compiled_ipv4(packet.clone());
+        let raw = decoded.layer::<crafter::Raw>().expect("Raw payload");
+
+        assert_eq!(raw.as_bytes(), b"hello");
+        assert_eq!(
+            context.get_tcp_snd_nxt(),
+            Some(SND_NXT.wrapping_add(PEER_MSS as u32))
         );
     }
 
@@ -1627,7 +1681,9 @@ mod tests {
             .expect("peer FIN transition matches")
             .fire(&peer_fin, &mut context)
             .expect("peer FIN transition should fire");
-        let ack = step.outgoing().expect("peer FIN transition sends final ACK");
+        let ack = step
+            .outgoing()
+            .expect("peer FIN transition sends final ACK");
         let tcp = ack.layer::<crafter::Tcp>().expect("TCP layer");
 
         assert_eq!(context.get_tcp_rcv_nxt(), Some(RCV_NXT.wrapping_add(1)));

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -7,7 +7,10 @@
 
 use std::net::Ipv4Addr;
 
-use crate::{Flow, FlowBuilderExt, FlowState, PacketContext, Role, Step};
+use crate::matcher::tcp_segment_for_ipv4;
+use crate::{
+    Flow, FlowBuilderExt, FlowError, FlowState, PacketContext, Role, Step, StepGotoExt, Transition,
+};
 
 const TCP_WINDOW: u16 = 64_240;
 const TCP_MSS: u16 = 1_460;
@@ -253,6 +256,50 @@ fn client_syn_sent_state(local_ip: Ipv4Addr, remote_ip: Ipv4Addr, remote_port: u
             Ok(Step::send(syn))
         })
         .entry_description("TCP SYN")
+        .on(client_syn_ack_transition(local_ip, remote_ip, remote_port))
+}
+
+fn client_syn_ack_transition(
+    local_ip: Ipv4Addr,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
+) -> Transition {
+    Transition::on(
+        tcp_segment_for_ipv4(
+            local_ip,
+            TCP_CLIENT_LOCAL_PORT,
+            remote_ip,
+            remote_port,
+            crafter::TCP_FLAG_SYN | crafter::TCP_FLAG_ACK,
+        )
+        .ack_matches_tcp_snd_nxt(),
+        move |packet, ctx| {
+            let tcp = packet.layer::<crafter::Tcp>().ok_or_else(|| {
+                FlowError::Capture("matched TCP SYN-ACK packet has no TCP layer".to_string())
+            })?;
+
+            ctx.set_tcp_rcv_nxt(tcp.sequence_number_value().wrapping_add(1));
+            if let Some(peer_mss) = tcp
+                .parsed_options()?
+                .iter()
+                .find_map(crafter::TcpOption::maximum_segment_size_value)
+            {
+                ctx.set_tcp_peer_mss(peer_mss);
+            }
+            ctx.set_tcp_peer_window(tcp.window_value());
+
+            let ack = ack_segment(
+                ctx,
+                local_ip,
+                TCP_CLIENT_LOCAL_PORT,
+                remote_ip,
+                remote_port,
+            );
+
+            Ok(Step::send(ack).goto(ESTABLISHED))
+        },
+    )
+    .targets([ESTABLISHED])
 }
 
 fn stub_state(name: &'static str, next: &'static str) -> FlowState {
@@ -396,6 +443,59 @@ mod tests {
         assert_eq!(context.get_tcp_remote_ipv4(), Some(remote_ipv4()));
     }
 
+    #[test]
+    fn tcp_client_syn_ack_transition_records_peer_and_sends_handshake_ack() {
+        const PEER_ISS: u32 = 0x5152_5354;
+        const PEER_WINDOW: u16 = 32_768;
+        const PEER_MSS: u16 = 1_200;
+
+        let mut flow = client_flow(local_ipv4(), remote_ipv4(), REMOTE_PORT, None);
+        let mut context = PacketContext::new();
+
+        flow.state_mut(SYN_SENT)
+            .expect("SynSent state exists")
+            .run_entry(&mut context)
+            .expect("SynSent entry should run")
+            .expect("SynSent entry should return a step");
+        let client_snd_nxt = context
+            .get_tcp_snd_nxt()
+            .expect("SynSent entry records snd_nxt");
+        let syn_ack = syn_ack_from_peer(PEER_ISS, client_snd_nxt, PEER_WINDOW, PEER_MSS);
+        let wrong_ack = syn_ack_from_peer(
+            PEER_ISS,
+            client_snd_nxt.wrapping_add(1),
+            PEER_WINDOW,
+            PEER_MSS,
+        );
+
+        {
+            let syn_sent = flow.state(SYN_SENT).expect("SynSent state exists");
+            let transition = &syn_sent.transitions()[0];
+            assert!(transition.matches(&syn_ack, &context));
+            assert!(!transition.matches(&wrong_ack, &context));
+        }
+
+        let step = flow
+            .state_mut(SYN_SENT)
+            .expect("SynSent state exists")
+            .find_transition(&syn_ack, &context)
+            .expect("SYN-ACK transition matches")
+            .fire(&syn_ack, &mut context)
+            .expect("SYN-ACK transition should fire");
+        let ack = step.outgoing().expect("SYN-ACK transition sends ACK");
+        let tcp = ack.layer::<crafter::Tcp>().expect("TCP layer");
+
+        assert_eq!(context.get_tcp_rcv_nxt(), Some(PEER_ISS.wrapping_add(1)));
+        assert_eq!(context.get_tcp_peer_mss(), Some(PEER_MSS));
+        assert_eq!(context.get_tcp_peer_window(), Some(PEER_WINDOW));
+        assert_eq!(tcp.source_port_value(), TCP_CLIENT_LOCAL_PORT);
+        assert_eq!(tcp.destination_port_value(), REMOTE_PORT);
+        assert_eq!(tcp.sequence_number_value(), client_snd_nxt);
+        assert_eq!(tcp.acknowledgment_number_value(), PEER_ISS.wrapping_add(1));
+        assert_eq!(tcp.flags_value(), TCP_FLAG_ACK);
+        assert_eq!(step.target(), Some(ESTABLISHED));
+    }
+
     fn assert_named_states(flow: &crate::Flow, expected: &[&str]) {
         for name in expected {
             assert!(flow.state(name).is_some(), "missing {name} state");
@@ -527,6 +627,26 @@ mod tests {
 
         Packet::decode_from_l3(NetworkLayer::Ipv4, compiled.as_bytes())
             .expect("TCP packet should decode")
+    }
+
+    fn syn_ack_from_peer(peer_seq: u32, ack: u32, window: u16, mss: u16) -> Packet {
+        let tcp = crafter::Tcp::new()
+            .sport(REMOTE_PORT)
+            .dport(TCP_CLIENT_LOCAL_PORT)
+            .seq(peer_seq)
+            .ack(ack)
+            .window(window)
+            .syn_ack_segment()
+            .tcp_option(TcpOption::maximum_segment_size(mss))
+            .expect("fixed peer TCP MSS option encodes");
+
+        compiled_ipv4(
+            crafter::Ipv4::new()
+                .src(remote_ipv4())
+                .dst(local_ipv4())
+                .protocol(crafter::IPPROTO_TCP)
+                / tcp,
+        )
     }
 
     fn assert_has_mss(tcp: &crafter::Tcp) {

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -16,6 +16,7 @@ const TCP_WINDOW: u16 = 64_240;
 const TCP_MSS: u16 = 1_460;
 const TCP_CLIENT_ISS: u32 = 0x1020_3040;
 const TCP_CLIENT_LOCAL_PORT: u16 = 49_152;
+const TCP_SERVER_ISS: u32 = 0x5060_7080;
 
 /// Initial client state: active open has sent or will send SYN.
 pub const SYN_SENT: &str = "SynSent";
@@ -229,12 +230,13 @@ pub fn client_flow(
 
 /// Build the TCP server flow scaffold.
 ///
-/// The address and port arguments are placeholders for the real TCP actions
-/// added by later steps. This scaffold only declares the lifecycle.
-pub fn server_flow(_local_ip: Ipv4Addr, _listen_port: u16) -> Flow {
+/// The server starts in passive-open Listen and answers the first matching SYN.
+/// Later steps add the final handshake ACK and established-state payload
+/// handling.
+pub fn server_flow(local_ip: Ipv4Addr, listen_port: u16) -> Flow {
     let flow = Flow::new("tcp-server")
         .role(Role::Responder)
-        .state(server_listen_state())
+        .state(server_listen_state(local_ip, listen_port))
         .state(stub_state(SYN_RECEIVED, ESTABLISHED))
         .state(stub_state(ESTABLISHED, CLOSE_WAIT))
         .state(stub_state(CLOSE_WAIT, LAST_ACK))
@@ -558,8 +560,56 @@ fn acknowledge_peer_fin(packet: &crafter::Packet, ctx: &mut PacketContext) {
     ctx.set_tcp_rcv_nxt(tcp.sequence_number_value().wrapping_add(1));
 }
 
-fn server_listen_state() -> FlowState {
-    FlowState::new(LISTEN)
+fn server_listen_state(local_ip: Ipv4Addr, listen_port: u16) -> FlowState {
+    FlowState::new(LISTEN).on(server_syn_transition(local_ip, listen_port))
+}
+
+fn server_syn_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
+    let matcher = predicate("tcp SYN to listen port", move |packet, _ctx| {
+        let Some(ipv4) = packet.layer::<crafter::Ipv4>() else {
+            return false;
+        };
+        if ipv4.destination() != local_ip {
+            return false;
+        }
+
+        packet.layer::<crafter::Tcp>().is_some_and(|tcp| {
+            tcp.destination_port_value() == listen_port
+                && tcp.flags_value() == crafter::TCP_FLAG_SYN
+        })
+    });
+
+    Transition::on(matcher, move |packet, ctx| {
+        let ipv4 = packet.layer::<crafter::Ipv4>().ok_or_else(|| {
+            FlowError::Capture("matched TCP SYN packet has no IPv4 layer".to_string())
+        })?;
+        let tcp = packet.layer::<crafter::Tcp>().ok_or_else(|| {
+            FlowError::Capture("matched TCP SYN packet has no TCP layer".to_string())
+        })?;
+        let remote_ip = ipv4.source();
+        let remote_port = tcp.source_port_value();
+        let iss = TCP_SERVER_ISS;
+
+        ctx.set_tcp_local_port(listen_port);
+        ctx.set_tcp_remote_port(remote_port);
+        ctx.set_tcp_remote_ipv4(remote_ip);
+        ctx.set_tcp_rcv_nxt(tcp.sequence_number_value().wrapping_add(1));
+        if let Some(peer_mss) = tcp
+            .parsed_options()?
+            .iter()
+            .find_map(crafter::TcpOption::maximum_segment_size_value)
+        {
+            ctx.set_tcp_peer_mss(peer_mss);
+        }
+        ctx.set_tcp_peer_window(tcp.window_value());
+        ctx.set_tcp_iss(iss);
+        ctx.set_tcp_snd_nxt(iss.wrapping_add(1));
+
+        let syn_ack = syn_ack_segment(ctx, local_ip, listen_port, remote_ip, remote_port);
+
+        Ok(Step::send(syn_ack).goto(SYN_RECEIVED))
+    })
+    .targets([SYN_RECEIVED])
 }
 
 fn stub_state(name: &'static str, next: &'static str) -> FlowState {
@@ -615,7 +665,8 @@ mod tests {
     use super::{
         ack_segment, client_flow, data_segment, fin_segment, server_flow, syn_ack_segment,
         syn_segment, CLOSED, CLOSE_WAIT, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, LAST_ACK, LISTEN,
-        SYN_RECEIVED, SYN_SENT, TCP_CLIENT_ISS, TCP_CLIENT_LOCAL_PORT, TCP_MSS, TCP_WINDOW,
+        SYN_RECEIVED, SYN_SENT, TCP_CLIENT_ISS, TCP_CLIENT_LOCAL_PORT, TCP_MSS, TCP_SERVER_ISS,
+        TCP_WINDOW,
     };
     use std::net::Ipv4Addr;
 
@@ -683,11 +734,85 @@ mod tests {
         );
         let listen = flow.state(LISTEN).expect("Listen state exists");
         assert!(!listen.has_entry(), "Listen must not send on entry");
+        assert_eq!(listen.transitions().len(), 1);
+        let show = flow.show();
         assert!(
-            listen.transitions().is_empty(),
-            "SYN transition is added in the next step"
+            show.contains("tcp SYN to listen port"),
+            "show() missing server SYN transition detail:\n{show}"
+        );
+        assert!(
+            show.contains("-> SynReceived"),
+            "show() missing server SYN transition target:\n{show}"
         );
         flow.validate().expect("TCP server scaffold is valid");
+    }
+
+    #[test]
+    fn tcp_server_listen_transition_records_client_and_sends_syn_ack() {
+        const CLIENT_ISS: u32 = 0x5152_5354;
+        const CLIENT_PORT: u16 = 49_153;
+        const LISTEN_PORT: u16 = 8080;
+        const CLIENT_WINDOW: u16 = 32_768;
+        const CLIENT_MSS: u16 = 1_200;
+
+        let mut flow = server_flow(local_ipv4(), LISTEN_PORT);
+        let mut context = PacketContext::new();
+        let syn = syn_to_server(
+            CLIENT_ISS,
+            CLIENT_PORT,
+            LISTEN_PORT,
+            CLIENT_WINDOW,
+            CLIENT_MSS,
+        );
+        let syn_ack_from_client = syn_ack_to_server(CLIENT_ISS, CLIENT_PORT, LISTEN_PORT);
+
+        {
+            let listen = flow.state(LISTEN).expect("Listen state exists");
+            let transition = &listen.transitions()[0];
+            assert!(transition.matches(&syn, &context));
+            assert!(
+                !transition.matches(&syn_ack_from_client, &context),
+                "Listen transition must require SYN with no ACK"
+            );
+        }
+
+        let step = flow
+            .state_mut(LISTEN)
+            .expect("Listen state exists")
+            .find_transition(&syn, &context)
+            .expect("SYN transition matches")
+            .fire(&syn, &mut context)
+            .expect("SYN transition should fire");
+        let syn_ack = step.outgoing().expect("SYN transition sends SYN-ACK");
+        let ipv4 = syn_ack.layer::<crafter::Ipv4>().expect("IPv4 layer");
+        let tcp = syn_ack.layer::<crafter::Tcp>().expect("TCP layer");
+
+        assert_eq!(context.get_tcp_local_port(), Some(LISTEN_PORT));
+        assert_eq!(context.get_tcp_remote_port(), Some(CLIENT_PORT));
+        assert_eq!(context.get_tcp_remote_ipv4(), Some(remote_ipv4()));
+        assert_eq!(
+            context.get_tcp_rcv_nxt(),
+            Some(CLIENT_ISS.wrapping_add(1))
+        );
+        assert_eq!(context.get_tcp_peer_mss(), Some(CLIENT_MSS));
+        assert_eq!(context.get_tcp_peer_window(), Some(CLIENT_WINDOW));
+        assert_eq!(context.get_tcp_iss(), Some(TCP_SERVER_ISS));
+        assert_eq!(
+            context.get_tcp_snd_nxt(),
+            Some(TCP_SERVER_ISS.wrapping_add(1))
+        );
+        assert_eq!(ipv4.source(), local_ipv4());
+        assert_eq!(ipv4.destination(), remote_ipv4());
+        assert_eq!(tcp.source_port_value(), LISTEN_PORT);
+        assert_eq!(tcp.destination_port_value(), CLIENT_PORT);
+        assert_eq!(tcp.sequence_number_value(), TCP_SERVER_ISS);
+        assert_eq!(
+            tcp.acknowledgment_number_value(),
+            CLIENT_ISS.wrapping_add(1)
+        );
+        assert_eq!(tcp.flags_value(), TCP_FLAG_SYN | TCP_FLAG_ACK);
+        assert_has_mss(tcp);
+        assert_eq!(step.target(), Some(SYN_RECEIVED));
     }
 
     #[test]
@@ -1108,6 +1233,49 @@ mod tests {
             .syn_ack_segment()
             .tcp_option(TcpOption::maximum_segment_size(mss))
             .expect("fixed peer TCP MSS option encodes");
+
+        compiled_ipv4(
+            crafter::Ipv4::new()
+                .src(remote_ipv4())
+                .dst(local_ipv4())
+                .protocol(crafter::IPPROTO_TCP)
+                / tcp,
+        )
+    }
+
+    fn syn_to_server(
+        client_seq: u32,
+        client_port: u16,
+        listen_port: u16,
+        window: u16,
+        mss: u16,
+    ) -> Packet {
+        let tcp = crafter::Tcp::new()
+            .sport(client_port)
+            .dport(listen_port)
+            .seq(client_seq)
+            .window(window)
+            .syn_segment()
+            .tcp_option(TcpOption::maximum_segment_size(mss))
+            .expect("fixed client TCP MSS option encodes");
+
+        compiled_ipv4(
+            crafter::Ipv4::new()
+                .src(remote_ipv4())
+                .dst(local_ipv4())
+                .protocol(crafter::IPPROTO_TCP)
+                / tcp,
+        )
+    }
+
+    fn syn_ack_to_server(client_seq: u32, client_port: u16, listen_port: u16) -> Packet {
+        let tcp = crafter::Tcp::new()
+            .sport(client_port)
+            .dport(listen_port)
+            .seq(client_seq)
+            .ack(TCP_SERVER_ISS.wrapping_add(1))
+            .window(TCP_WINDOW)
+            .syn_ack_segment();
 
         compiled_ipv4(
             crafter::Ipv4::new()

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -51,6 +51,76 @@ fn syn_segment(
     )
 }
 
+#[cfg(test)]
+mod api_check {
+    use std::net::Ipv4Addr;
+
+    use crafter::{
+        Ipv4, NetworkLayer, Packet, Tcp, TcpOption, IPPROTO_TCP, TCP_FLAG_ACK, TCP_FLAG_FIN,
+        TCP_FLAG_PSH, TCP_FLAG_RST, TCP_FLAG_SYN,
+    };
+
+    use super::{TCP_MSS, TCP_WINDOW};
+
+    #[test]
+    fn tcp_builder_and_accessor_surface_round_trips() {
+        const LOCAL_PORT: u16 = 49_152;
+        const REMOTE_PORT: u16 = 443;
+        const SEQ: u32 = 0x1020_3040;
+        const ACK: u32 = 0x5060_7080;
+
+        assert_eq!(Tcp::new().syn_segment().flags_value(), TCP_FLAG_SYN);
+        assert_eq!(
+            Tcp::new().syn_ack_segment().flags_value(),
+            TCP_FLAG_SYN | TCP_FLAG_ACK
+        );
+        assert_eq!(Tcp::new().fin_ack_segment().flags_value(), TCP_FLAG_FIN | TCP_FLAG_ACK);
+
+        let tcp = Tcp::new()
+            .sport(LOCAL_PORT)
+            .dport(REMOTE_PORT)
+            .seq(SEQ)
+            .ack(ACK)
+            .window(TCP_WINDOW)
+            .syn_segment()
+            .ack_segment()
+            .syn()
+            .fin()
+            .psh()
+            .rst()
+            .tcp_option(TcpOption::maximum_segment_size(TCP_MSS))
+            .expect("fixed TCP MSS option encodes");
+
+        let packet = Ipv4::new()
+            .src(Ipv4Addr::new(192, 0, 2, 10))
+            .dst(Ipv4Addr::new(198, 51, 100, 20))
+            .protocol(IPPROTO_TCP)
+            / tcp;
+        let compiled = packet.compile().expect("TCP packet should compile");
+        let decoded = Packet::decode_from_l3(NetworkLayer::Ipv4, compiled.as_bytes())
+            .expect("TCP packet should decode");
+        let tcp = decoded.layer::<Tcp>().expect("TCP layer");
+
+        let expected_flags =
+            TCP_FLAG_SYN | TCP_FLAG_ACK | TCP_FLAG_FIN | TCP_FLAG_PSH | TCP_FLAG_RST;
+        assert_eq!(tcp.source_port_value(), LOCAL_PORT);
+        assert_eq!(tcp.destination_port_value(), REMOTE_PORT);
+        assert_eq!(tcp.sequence_number_value(), SEQ);
+        assert_eq!(tcp.acknowledgment_number_value(), ACK);
+        assert_eq!(tcp.window_value(), TCP_WINDOW);
+        assert_eq!(tcp.flags_value(), expected_flags);
+        assert!(tcp.has_syn());
+        assert!(tcp.has_fin());
+        assert!(tcp.has_flag(TCP_FLAG_ACK));
+        assert!(tcp.has_flag(TCP_FLAG_PSH));
+        assert!(tcp.has_flag(TCP_FLAG_RST));
+        assert_eq!(
+            tcp.parsed_options().expect("TCP options should decode"),
+            [TcpOption::maximum_segment_size(TCP_MSS)]
+        );
+    }
+}
+
 fn syn_ack_segment(
     ctx: &PacketContext,
     local_ip: Ipv4Addr,

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -217,8 +217,8 @@ pub fn client_flow(
             remote_port,
             payload,
         ))
-        .state(stub_state(FIN_WAIT_1, FIN_WAIT_2))
-        .state(stub_state(FIN_WAIT_2, CLOSED))
+        .state(client_fin_wait_1_state(local_ip, remote_ip, remote_port))
+        .state(client_fin_wait_2_state(local_ip, remote_ip, remote_port))
         .state(terminal_state(CLOSED))
         .initial(SYN_SENT)
 }
@@ -383,8 +383,148 @@ fn client_data_transition(
             remote_port,
         );
 
-        Ok(Step::send(ack))
+        Ok(Step::send(ack).goto(FIN_WAIT_1))
     })
+    .targets([FIN_WAIT_1])
+}
+
+fn client_fin_wait_1_state(
+    local_ip: Ipv4Addr,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
+) -> FlowState {
+    FlowState::new(FIN_WAIT_1)
+        .on_entry(move |ctx| {
+            let fin = fin_segment(
+                ctx,
+                local_ip,
+                TCP_CLIENT_LOCAL_PORT,
+                remote_ip,
+                remote_port,
+            );
+            let snd_nxt = tcp_snd_nxt(ctx).wrapping_add(1);
+            ctx.set_tcp_snd_nxt(snd_nxt);
+
+            Ok(Step::send(fin))
+        })
+        .entry_description("TCP FIN-ACK active close")
+        .on(client_fin_wait_1_fin_transition(
+            local_ip,
+            remote_ip,
+            remote_port,
+        ))
+        .on(client_fin_wait_1_ack_transition(
+            local_ip,
+            remote_ip,
+            remote_port,
+        ))
+}
+
+fn client_fin_wait_1_ack_transition(
+    local_ip: Ipv4Addr,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
+) -> Transition {
+    let matcher = tcp_segment_for_ipv4(
+        local_ip,
+        TCP_CLIENT_LOCAL_PORT,
+        remote_ip,
+        remote_port,
+        crafter::TCP_FLAG_ACK,
+    )
+    .ack_matches_tcp_snd_nxt()
+    .and(predicate("tcp ACK segment has no FIN", |packet, _ctx| {
+        packet
+            .layer::<crafter::Tcp>()
+            .is_some_and(|tcp| !tcp.has_fin())
+    }));
+
+    Transition::on(matcher, |_packet, _ctx| Ok(Step::goto(FIN_WAIT_2))).targets([FIN_WAIT_2])
+}
+
+fn client_fin_wait_1_fin_transition(
+    local_ip: Ipv4Addr,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
+) -> Transition {
+    Transition::on(
+        peer_fin_matcher(local_ip, remote_ip, remote_port),
+        move |packet, ctx| {
+            acknowledge_peer_fin(packet, ctx);
+            let ack = ack_segment(
+                ctx,
+                local_ip,
+                TCP_CLIENT_LOCAL_PORT,
+                remote_ip,
+                remote_port,
+            );
+
+            Ok(Step::send(ack).goto(CLOSED))
+        },
+    )
+    .targets([CLOSED])
+}
+
+fn client_fin_wait_2_state(
+    local_ip: Ipv4Addr,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
+) -> FlowState {
+    FlowState::new(FIN_WAIT_2).on(client_fin_wait_2_fin_transition(
+        local_ip,
+        remote_ip,
+        remote_port,
+    ))
+}
+
+fn client_fin_wait_2_fin_transition(
+    local_ip: Ipv4Addr,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
+) -> Transition {
+    Transition::on(
+        peer_fin_matcher(local_ip, remote_ip, remote_port),
+        move |packet, ctx| {
+            acknowledge_peer_fin(packet, ctx);
+            let ack = ack_segment(
+                ctx,
+                local_ip,
+                TCP_CLIENT_LOCAL_PORT,
+                remote_ip,
+                remote_port,
+            );
+
+            Ok(Step::send(ack).goto(CLOSED))
+        },
+    )
+    .targets([CLOSED])
+}
+
+fn peer_fin_matcher(
+    local_ip: Ipv4Addr,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
+) -> impl crate::Matcher {
+    tcp_segment_for_ipv4(
+        local_ip,
+        TCP_CLIENT_LOCAL_PORT,
+        remote_ip,
+        remote_port,
+        crafter::TCP_FLAG_FIN | crafter::TCP_FLAG_ACK,
+    )
+    .ack_matches_tcp_snd_nxt()
+    .and(predicate("tcp FIN seq == tcp_rcv_nxt", |packet, ctx| {
+        packet.layer::<crafter::Tcp>().is_some_and(|tcp| {
+            ctx.get_tcp_rcv_nxt() == Some(tcp.sequence_number_value())
+        })
+    }))
+}
+
+fn acknowledge_peer_fin(packet: &crafter::Packet, ctx: &mut PacketContext) {
+    let tcp = packet
+        .layer::<crafter::Tcp>()
+        .expect("matched TCP FIN packet has no TCP layer");
+    ctx.set_tcp_rcv_nxt(tcp.sequence_number_value().wrapping_add(1));
 }
 
 fn stub_state(name: &'static str, next: &'static str) -> FlowState {
@@ -657,7 +797,116 @@ mod tests {
         assert_eq!(tcp.sequence_number_value(), SND_NXT);
         assert_eq!(tcp.acknowledgment_number_value(), expected_rcv_nxt);
         assert_eq!(tcp.flags_value(), TCP_FLAG_ACK);
+        assert_eq!(step.target(), Some(FIN_WAIT_1));
+    }
+
+    #[test]
+    fn tcp_client_fin_wait1_entry_sends_fin_and_advances_snd_nxt() {
+        let mut flow = client_flow(local_ipv4(), remote_ipv4(), REMOTE_PORT, None);
+        let mut context = tcp_context();
+
+        let step = flow
+            .state_mut(FIN_WAIT_1)
+            .expect("FinWait1 state exists")
+            .run_entry(&mut context)
+            .expect("FinWait1 entry should run")
+            .expect("FinWait1 entry should return a step");
+        let packet = step.outgoing().expect("FinWait1 entry sends FIN");
+        let tcp = packet.layer::<crafter::Tcp>().expect("TCP layer");
+
         assert_eq!(step.target(), None);
+        assert!(step.expects_reply());
+        assert_eq!(tcp.source_port_value(), TCP_CLIENT_LOCAL_PORT);
+        assert_eq!(tcp.destination_port_value(), REMOTE_PORT);
+        assert_eq!(tcp.sequence_number_value(), SND_NXT);
+        assert_eq!(tcp.acknowledgment_number_value(), RCV_NXT);
+        assert_eq!(tcp.flags_value(), TCP_FLAG_FIN | TCP_FLAG_ACK);
+        assert_eq!(context.get_tcp_snd_nxt(), Some(SND_NXT.wrapping_add(1)));
+    }
+
+    #[test]
+    fn tcp_client_fin_wait1_ack_transition_reaches_fin_wait2() {
+        let mut flow = client_flow(local_ipv4(), remote_ipv4(), REMOTE_PORT, None);
+        let mut context = tcp_context();
+        context.set_tcp_snd_nxt(SND_NXT.wrapping_add(1));
+        let peer_ack = ack_from_peer(RCV_NXT, SND_NXT.wrapping_add(1));
+        let wrong_ack = ack_from_peer(RCV_NXT, SND_NXT);
+
+        {
+            let fin_wait1 = flow.state(FIN_WAIT_1).expect("FinWait1 state exists");
+            let transition = &fin_wait1.transitions()[1];
+            assert!(transition.matches(&peer_ack, &context));
+            assert!(!transition.matches(&wrong_ack, &context));
+        }
+
+        let step = flow
+            .state_mut(FIN_WAIT_1)
+            .expect("FinWait1 state exists")
+            .find_transition(&peer_ack, &context)
+            .expect("FIN ACK transition matches")
+            .fire(&peer_ack, &mut context)
+            .expect("FIN ACK transition should fire");
+
+        assert_eq!(context.get_tcp_rcv_nxt(), Some(RCV_NXT));
+        assert!(step.outgoing().is_none());
+        assert_eq!(step.target(), Some(FIN_WAIT_2));
+    }
+
+    #[test]
+    fn tcp_client_fin_wait2_fin_transition_sends_final_ack_and_closes() {
+        let mut flow = client_flow(local_ipv4(), remote_ipv4(), REMOTE_PORT, None);
+        let mut context = tcp_context();
+        let peer_fin = fin_ack_from_peer(RCV_NXT, SND_NXT);
+
+        {
+            let fin_wait2 = flow.state(FIN_WAIT_2).expect("FinWait2 state exists");
+            let transition = &fin_wait2.transitions()[0];
+            assert!(transition.matches(&peer_fin, &context));
+        }
+
+        let step = flow
+            .state_mut(FIN_WAIT_2)
+            .expect("FinWait2 state exists")
+            .find_transition(&peer_fin, &context)
+            .expect("peer FIN transition matches")
+            .fire(&peer_fin, &mut context)
+            .expect("peer FIN transition should fire");
+        let ack = step.outgoing().expect("peer FIN transition sends final ACK");
+        let tcp = ack.layer::<crafter::Tcp>().expect("TCP layer");
+
+        assert_eq!(context.get_tcp_rcv_nxt(), Some(RCV_NXT.wrapping_add(1)));
+        assert_eq!(tcp.source_port_value(), TCP_CLIENT_LOCAL_PORT);
+        assert_eq!(tcp.destination_port_value(), REMOTE_PORT);
+        assert_eq!(tcp.sequence_number_value(), SND_NXT);
+        assert_eq!(tcp.acknowledgment_number_value(), RCV_NXT.wrapping_add(1));
+        assert_eq!(tcp.flags_value(), TCP_FLAG_ACK);
+        assert_eq!(step.target(), Some(CLOSED));
+    }
+
+    #[test]
+    fn tcp_client_fin_wait1_combined_fin_ack_sends_final_ack_and_closes() {
+        let mut flow = client_flow(local_ipv4(), remote_ipv4(), REMOTE_PORT, None);
+        let mut context = tcp_context();
+        context.set_tcp_snd_nxt(SND_NXT.wrapping_add(1));
+        let peer_fin_ack = fin_ack_from_peer(RCV_NXT, SND_NXT.wrapping_add(1));
+
+        let step = flow
+            .state_mut(FIN_WAIT_1)
+            .expect("FinWait1 state exists")
+            .find_transition(&peer_fin_ack, &context)
+            .expect("combined FIN-ACK transition matches")
+            .fire(&peer_fin_ack, &mut context)
+            .expect("combined FIN-ACK transition should fire");
+        let ack = step
+            .outgoing()
+            .expect("combined FIN-ACK transition sends final ACK");
+        let tcp = ack.layer::<crafter::Tcp>().expect("TCP layer");
+
+        assert_eq!(context.get_tcp_rcv_nxt(), Some(RCV_NXT.wrapping_add(1)));
+        assert_eq!(tcp.sequence_number_value(), SND_NXT.wrapping_add(1));
+        assert_eq!(tcp.acknowledgment_number_value(), RCV_NXT.wrapping_add(1));
+        assert_eq!(tcp.flags_value(), TCP_FLAG_ACK);
+        assert_eq!(step.target(), Some(CLOSED));
     }
 
     fn assert_named_states(flow: &crate::Flow, expected: &[&str]) {
@@ -841,6 +1090,24 @@ mod tests {
             .ack(ack)
             .window(TCP_WINDOW)
             .ack_segment();
+
+        compiled_ipv4(
+            crafter::Ipv4::new()
+                .src(remote_ipv4())
+                .dst(local_ipv4())
+                .protocol(crafter::IPPROTO_TCP)
+                / tcp,
+        )
+    }
+
+    fn fin_ack_from_peer(peer_seq: u32, ack: u32) -> Packet {
+        let tcp = crafter::Tcp::new()
+            .sport(REMOTE_PORT)
+            .dport(TCP_CLIENT_LOCAL_PORT)
+            .seq(peer_seq)
+            .ack(ack)
+            .window(TCP_WINDOW)
+            .fin_ack_segment();
 
         compiled_ipv4(
             crafter::Ipv4::new()

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -7,7 +7,10 @@
 
 use std::net::Ipv4Addr;
 
-use crate::{Flow, FlowBuilderExt, FlowState, Role, Step};
+use crate::{Flow, FlowBuilderExt, FlowState, PacketContext, Role, Step};
+
+const TCP_WINDOW: u16 = 64_240;
+const TCP_MSS: u16 = 1_460;
 
 /// Initial client state: active open has sent or will send SYN.
 pub const SYN_SENT: &str = "SynSent";
@@ -29,6 +32,96 @@ pub const CLOSE_WAIT: &str = "CloseWait";
 pub const LAST_ACK: &str = "LastAck";
 /// Terminal server state after graceful close completes.
 pub const CLOSED_SRV: &str = "ClosedSrv";
+
+fn syn_segment(
+    ctx: &PacketContext,
+    local_ip: Ipv4Addr,
+    local_port: u16,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
+) -> crafter::Packet {
+    ipv4_tcp_packet(
+        local_ip,
+        remote_ip,
+        tcp_with_mss(
+            tcp_header(local_port, remote_port)
+                .seq(tcp_iss(ctx))
+                .syn_segment(),
+        ),
+    )
+}
+
+fn syn_ack_segment(
+    ctx: &PacketContext,
+    local_ip: Ipv4Addr,
+    local_port: u16,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
+) -> crafter::Packet {
+    ipv4_tcp_packet(
+        local_ip,
+        remote_ip,
+        tcp_with_mss(
+            tcp_header(local_port, remote_port)
+                .seq(tcp_iss(ctx))
+                .ack(tcp_rcv_nxt(ctx))
+                .syn_ack_segment(),
+        ),
+    )
+}
+
+fn ack_segment(
+    ctx: &PacketContext,
+    local_ip: Ipv4Addr,
+    local_port: u16,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
+) -> crafter::Packet {
+    ipv4_tcp_packet(
+        local_ip,
+        remote_ip,
+        tcp_header(local_port, remote_port)
+            .seq(tcp_snd_nxt(ctx))
+            .ack(tcp_rcv_nxt(ctx))
+            .ack_segment(),
+    )
+}
+
+fn data_segment(
+    ctx: &PacketContext,
+    local_ip: Ipv4Addr,
+    local_port: u16,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
+    payload: impl AsRef<[u8]>,
+) -> crafter::Packet {
+    ipv4_tcp_packet(
+        local_ip,
+        remote_ip,
+        tcp_header(local_port, remote_port)
+            .seq(tcp_snd_nxt(ctx))
+            .ack(tcp_rcv_nxt(ctx))
+            .ack_segment()
+            .psh(),
+    ) / crafter::Raw::from_bytes(payload)
+}
+
+fn fin_segment(
+    ctx: &PacketContext,
+    local_ip: Ipv4Addr,
+    local_port: u16,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
+) -> crafter::Packet {
+    ipv4_tcp_packet(
+        local_ip,
+        remote_ip,
+        tcp_header(local_port, remote_port)
+            .seq(tcp_snd_nxt(ctx))
+            .ack(tcp_rcv_nxt(ctx))
+            .fin_ack_segment(),
+    )
+}
 
 /// Build the TCP client flow scaffold.
 ///
@@ -79,13 +172,61 @@ fn terminal_state(name: &'static str) -> FlowState {
         .entry_terminal()
 }
 
+fn ipv4_tcp_packet(local_ip: Ipv4Addr, remote_ip: Ipv4Addr, tcp: crafter::Tcp) -> crafter::Packet {
+    crafter::Ipv4::new()
+        .src(local_ip)
+        .dst(remote_ip)
+        .protocol(crafter::IPPROTO_TCP)
+        / tcp
+}
+
+fn tcp_header(local_port: u16, remote_port: u16) -> crafter::Tcp {
+    crafter::Tcp::new()
+        .sport(local_port)
+        .dport(remote_port)
+        .window(TCP_WINDOW)
+}
+
+fn tcp_with_mss(tcp: crafter::Tcp) -> crafter::Tcp {
+    tcp.tcp_option(crafter::TcpOption::maximum_segment_size(TCP_MSS))
+        .expect("fixed TCP MSS option encodes")
+}
+
+fn tcp_iss(ctx: &PacketContext) -> u32 {
+    ctx.get_tcp_iss()
+        .expect("TCP segment build requires tcp_iss in PacketContext")
+}
+
+fn tcp_snd_nxt(ctx: &PacketContext) -> u32 {
+    ctx.get_tcp_snd_nxt()
+        .expect("TCP segment build requires tcp_snd_nxt in PacketContext")
+}
+
+fn tcp_rcv_nxt(ctx: &PacketContext) -> u32 {
+    ctx.get_tcp_rcv_nxt()
+        .expect("TCP segment build requires tcp_rcv_nxt in PacketContext")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        client_flow, server_flow, CLOSED, CLOSED_SRV, CLOSE_WAIT, ESTABLISHED, FIN_WAIT_1,
-        FIN_WAIT_2, LAST_ACK, LISTEN, SYN_RECEIVED, SYN_SENT,
+        ack_segment, client_flow, data_segment, fin_segment, server_flow, syn_ack_segment,
+        syn_segment, CLOSED, CLOSED_SRV, CLOSE_WAIT, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, LAST_ACK,
+        LISTEN, SYN_RECEIVED, SYN_SENT, TCP_MSS, TCP_WINDOW,
     };
-    use crate::{docaddr, Role};
+    use std::net::Ipv4Addr;
+
+    use crafter::{
+        NetworkLayer, Packet, TcpOption, TCP_FLAG_ACK, TCP_FLAG_FIN, TCP_FLAG_PSH, TCP_FLAG_SYN,
+    };
+
+    use crate::{docaddr, PacketContext, Role};
+
+    const ISS: u32 = 0x2122_2324;
+    const SND_NXT: u32 = 0x3132_3334;
+    const RCV_NXT: u32 = 0x4142_4344;
+    const LOCAL_PORT: u16 = 49_152;
+    const REMOTE_PORT: u16 = 443;
 
     #[test]
     fn tcp_client_flow_exposes_initial_and_named_states() {
@@ -98,7 +239,10 @@ mod tests {
 
         assert_eq!(flow.role(), Role::Initiator);
         assert_eq!(flow.initial(), SYN_SENT);
-        assert_named_states(&flow, &[SYN_SENT, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, CLOSED]);
+        assert_named_states(
+            &flow,
+            &[SYN_SENT, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, CLOSED],
+        );
         flow.validate().expect("TCP client scaffold is valid");
     }
 
@@ -126,5 +270,138 @@ mod tests {
         for name in expected {
             assert!(flow.state(name).is_some(), "missing {name} state");
         }
+    }
+
+    #[test]
+    fn tcp_syn_segment_uses_context_iss_and_mss_option() {
+        let context = tcp_context();
+        let packet = syn_segment(
+            &context,
+            local_ipv4(),
+            LOCAL_PORT,
+            remote_ipv4(),
+            REMOTE_PORT,
+        );
+        let tcp = packet.layer::<crafter::Tcp>().expect("TCP layer");
+
+        assert_eq!(tcp.source_port_value(), LOCAL_PORT);
+        assert_eq!(tcp.destination_port_value(), REMOTE_PORT);
+        assert_eq!(tcp.sequence_number_value(), ISS);
+        assert_eq!(tcp.acknowledgment_number_value(), 0);
+        assert_eq!(tcp.flags_value(), TCP_FLAG_SYN);
+        assert_eq!(tcp.window_value(), TCP_WINDOW);
+        assert_has_mss(tcp);
+    }
+
+    #[test]
+    fn tcp_syn_ack_segment_uses_context_iss_rcv_nxt_and_mss_option() {
+        let context = tcp_context();
+        let packet = syn_ack_segment(
+            &context,
+            local_ipv4(),
+            LOCAL_PORT,
+            remote_ipv4(),
+            REMOTE_PORT,
+        );
+        let tcp = packet.layer::<crafter::Tcp>().expect("TCP layer");
+
+        assert_eq!(tcp.sequence_number_value(), ISS);
+        assert_eq!(tcp.acknowledgment_number_value(), RCV_NXT);
+        assert_eq!(tcp.flags_value(), TCP_FLAG_SYN | TCP_FLAG_ACK);
+        assert_eq!(tcp.window_value(), TCP_WINDOW);
+        assert_has_mss(tcp);
+    }
+
+    #[test]
+    fn tcp_ack_segment_uses_context_snd_nxt_and_rcv_nxt() {
+        let context = tcp_context();
+        let packet = ack_segment(
+            &context,
+            local_ipv4(),
+            LOCAL_PORT,
+            remote_ipv4(),
+            REMOTE_PORT,
+        );
+        let tcp = packet.layer::<crafter::Tcp>().expect("TCP layer");
+
+        assert_eq!(tcp.sequence_number_value(), SND_NXT);
+        assert_eq!(tcp.acknowledgment_number_value(), RCV_NXT);
+        assert_eq!(tcp.flags_value(), TCP_FLAG_ACK);
+        assert_eq!(tcp.window_value(), TCP_WINDOW);
+        assert!(packet.layer::<crafter::Raw>().is_none());
+    }
+
+    #[test]
+    fn tcp_data_segment_uses_context_numbers_and_carries_payload() {
+        let context = tcp_context();
+        let payload = b"hello over tcp";
+        let packet = data_segment(
+            &context,
+            local_ipv4(),
+            LOCAL_PORT,
+            remote_ipv4(),
+            REMOTE_PORT,
+            payload,
+        );
+        let decoded = compiled_ipv4(packet);
+        let ipv4 = decoded.layer::<crafter::Ipv4>().expect("IPv4 layer");
+        let tcp = decoded.layer::<crafter::Tcp>().expect("TCP layer");
+        let raw = decoded.layer::<crafter::Raw>().expect("Raw payload");
+
+        assert_eq!(tcp.sequence_number_value(), SND_NXT);
+        assert_eq!(tcp.acknowledgment_number_value(), RCV_NXT);
+        assert_eq!(tcp.flags_value(), TCP_FLAG_PSH | TCP_FLAG_ACK);
+        assert_eq!(raw.as_bytes(), payload);
+        assert_eq!(
+            ipv4.total_length_value(),
+            Some((ipv4.header_len() + tcp.header_len() + payload.len()) as u16)
+        );
+    }
+
+    #[test]
+    fn tcp_fin_segment_uses_context_snd_nxt_and_rcv_nxt() {
+        let context = tcp_context();
+        let packet = fin_segment(
+            &context,
+            local_ipv4(),
+            LOCAL_PORT,
+            remote_ipv4(),
+            REMOTE_PORT,
+        );
+        let tcp = packet.layer::<crafter::Tcp>().expect("TCP layer");
+
+        assert_eq!(tcp.sequence_number_value(), SND_NXT);
+        assert_eq!(tcp.acknowledgment_number_value(), RCV_NXT);
+        assert_eq!(tcp.flags_value(), TCP_FLAG_FIN | TCP_FLAG_ACK);
+        assert_eq!(tcp.window_value(), TCP_WINDOW);
+    }
+
+    fn tcp_context() -> PacketContext {
+        let mut context = PacketContext::new();
+        context.set_tcp_iss(ISS);
+        context.set_tcp_snd_nxt(SND_NXT);
+        context.set_tcp_rcv_nxt(RCV_NXT);
+        context
+    }
+
+    fn local_ipv4() -> Ipv4Addr {
+        Ipv4Addr::new(192, 0, 2, 10)
+    }
+
+    fn remote_ipv4() -> Ipv4Addr {
+        Ipv4Addr::new(198, 51, 100, 20)
+    }
+
+    fn compiled_ipv4(packet: crafter::Packet) -> Packet {
+        let compiled = packet.compile().expect("TCP packet should compile");
+
+        Packet::decode_from_l3(NetworkLayer::Ipv4, compiled.as_bytes())
+            .expect("TCP packet should decode")
+    }
+
+    fn assert_has_mss(tcp: &crafter::Tcp) {
+        let options = tcp.parsed_options().expect("TCP options should decode");
+
+        assert_eq!(options, [TcpOption::maximum_segment_size(TCP_MSS)]);
     }
 }

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -266,6 +266,7 @@ fn client_syn_sent_state(local_ip: Ipv4Addr, remote_ip: Ipv4Addr, remote_port: u
         })
         .entry_description("TCP SYN")
         .on(client_syn_ack_transition(local_ip, remote_ip, remote_port))
+        .on(client_rst_transition(local_ip, remote_ip, remote_port))
 }
 
 fn client_syn_ack_transition(
@@ -339,6 +340,7 @@ fn client_established_state(
         .entry_description("TCP PSH-ACK data")
         .entry_targets([FIN_WAIT_1])
         .on(client_data_transition(local_ip, remote_ip, remote_port))
+        .on(client_rst_transition(local_ip, remote_ip, remote_port))
 }
 
 fn client_data_transition(
@@ -422,6 +424,7 @@ fn client_fin_wait_1_state(
             remote_ip,
             remote_port,
         ))
+        .on(client_rst_transition(local_ip, remote_ip, remote_port))
 }
 
 fn client_fin_wait_1_ack_transition(
@@ -437,10 +440,10 @@ fn client_fin_wait_1_ack_transition(
         crafter::TCP_FLAG_ACK,
     )
     .ack_matches_tcp_snd_nxt()
-    .and(predicate("tcp ACK segment has no FIN", |packet, _ctx| {
-        packet
-            .layer::<crafter::Tcp>()
-            .is_some_and(|tcp| !tcp.has_fin())
+    .and(predicate("tcp ACK segment has no FIN or RST", |packet, _ctx| {
+        packet.layer::<crafter::Tcp>().is_some_and(|tcp| {
+            !tcp.has_fin() && !tcp.has_flag(crafter::TCP_FLAG_RST)
+        })
     }));
 
     Transition::on(matcher, |_packet, _ctx| Ok(Step::goto(FIN_WAIT_2))).targets([FIN_WAIT_2])
@@ -479,6 +482,26 @@ fn client_fin_wait_2_state(
         remote_ip,
         remote_port,
     ))
+    .on(client_rst_transition(local_ip, remote_ip, remote_port))
+}
+
+fn client_rst_transition(
+    local_ip: Ipv4Addr,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
+) -> Transition {
+    Transition::on(
+        tcp_segment_for_ipv4(
+            local_ip,
+            TCP_CLIENT_LOCAL_PORT,
+            remote_ip,
+            remote_port,
+            crafter::TCP_FLAG_RST,
+        )
+        .ack_matches_tcp_snd_nxt(),
+        |_packet, _ctx| Ok(Step::goto(CLOSED)),
+    )
+    .targets([CLOSED])
 }
 
 fn client_fin_wait_2_fin_transition(

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -208,7 +208,7 @@ pub fn client_flow(
     remote_port: u16,
     payload: Option<Vec<u8>>,
 ) -> Flow {
-    Flow::new("tcp-client")
+    let flow = Flow::new("tcp-client")
         .role(Role::Initiator)
         .state(client_syn_sent_state(local_ip, remote_ip, remote_port))
         .state(client_established_state(
@@ -220,7 +220,11 @@ pub fn client_flow(
         .state(client_fin_wait_1_state(local_ip, remote_ip, remote_port))
         .state(client_fin_wait_2_state(local_ip, remote_ip, remote_port))
         .state(terminal_state(CLOSED))
-        .initial(SYN_SENT)
+        .initial(SYN_SENT);
+
+    flow.validate()
+        .expect("TCP client flow shape should validate");
+    flow
 }
 
 /// Build the TCP server flow scaffold.
@@ -611,7 +615,29 @@ mod tests {
             &flow,
             &[SYN_SENT, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, CLOSED],
         );
-        flow.validate().expect("TCP client scaffold is valid");
+        assert!(flow.validate().is_ok());
+
+        let show = flow.show();
+        for expected in [SYN_SENT, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, CLOSED] {
+            assert!(show.contains(expected), "show() missing state {expected}");
+        }
+        for expected in [
+            "TCP SYN",
+            "flags include 0x012",
+            "-> Established",
+            "TCP PSH-ACK data",
+            "tcp data seq == tcp_rcv_nxt",
+            "-> FinWait1",
+            "TCP FIN-ACK active close",
+            "-> FinWait2",
+            "tcp FIN seq == tcp_rcv_nxt",
+            "-> Closed [terminal]",
+        ] {
+            assert!(
+                show.contains(expected),
+                "show() missing client transition detail {expected:?}:\n{show}"
+            );
+        }
     }
 
     #[test]

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -232,14 +232,13 @@ pub fn client_flow(
 /// Build the TCP server flow scaffold.
 ///
 /// The server starts in passive-open Listen and answers the first matching SYN.
-/// Later steps add the final handshake ACK and established-state payload
-/// handling.
-pub fn server_flow(local_ip: Ipv4Addr, listen_port: u16) -> Flow {
+/// When `response` is set, received client data is answered with that payload.
+pub fn server_flow(local_ip: Ipv4Addr, listen_port: u16, response: Option<Vec<u8>>) -> Flow {
     let flow = Flow::new("tcp-server")
         .role(Role::Responder)
         .state(server_listen_state(local_ip, listen_port))
         .state(server_syn_received_state(local_ip, listen_port))
-        .state(server_established_state(local_ip, listen_port))
+        .state(server_established_state(local_ip, listen_port, response))
         .state(stub_state(CLOSE_WAIT, LAST_ACK))
         .state(stub_state(LAST_ACK, CLOSED))
         .state(terminal_state(CLOSED))
@@ -569,8 +568,12 @@ fn server_syn_received_state(local_ip: Ipv4Addr, listen_port: u16) -> FlowState 
     FlowState::new(SYN_RECEIVED).on(server_final_ack_transition(local_ip, listen_port))
 }
 
-fn server_established_state(local_ip: Ipv4Addr, listen_port: u16) -> FlowState {
-    FlowState::new(ESTABLISHED).on(server_data_transition(local_ip, listen_port))
+fn server_established_state(
+    local_ip: Ipv4Addr,
+    listen_port: u16,
+    response: Option<Vec<u8>>,
+) -> FlowState {
+    FlowState::new(ESTABLISHED).on(server_data_transition(local_ip, listen_port, response))
 }
 
 fn server_syn_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
@@ -658,7 +661,11 @@ fn server_final_ack_matcher(local_ip: Ipv4Addr, listen_port: u16) -> impl crate:
     )
 }
 
-fn server_data_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
+fn server_data_transition(
+    local_ip: Ipv4Addr,
+    listen_port: u16,
+    response: Option<Vec<u8>>,
+) -> Transition {
     Transition::on(server_data_matcher(local_ip, listen_port), move |packet, ctx| {
         let raw = packet.layer::<crafter::Raw>().ok_or_else(|| {
             FlowError::Capture("matched TCP server data packet has no Raw payload".to_string())
@@ -675,6 +682,14 @@ fn server_data_transition(local_ip: Ipv4Addr, listen_port: u16) -> Transition {
         let remote_port = ctx.get_tcp_remote_port().ok_or_else(|| {
             FlowError::Capture("matched TCP server data packet has no remote port".to_string())
         })?;
+        if let Some(response) = response.as_deref() {
+            let data = data_segment(ctx, local_ip, listen_port, remote_ip, remote_port, response);
+            let snd_nxt = tcp_snd_nxt(ctx).wrapping_add(response.len() as u32);
+            ctx.set_tcp_snd_nxt(snd_nxt);
+
+            return Ok(Step::send(data));
+        }
+
         let ack = ack_segment(ctx, local_ip, listen_port, remote_ip, remote_port);
 
         Ok(Step::send(ack))
@@ -829,7 +844,7 @@ mod tests {
 
     #[test]
     fn tcp_server_flow_exposes_initial_and_named_states() {
-        let flow = server_flow(docaddr::SERVER_IPV4, 80);
+        let flow = server_flow(docaddr::SERVER_IPV4, 80, None);
 
         assert_eq!(flow.role(), Role::Responder);
         assert_eq!(flow.initial(), LISTEN);
@@ -860,7 +875,7 @@ mod tests {
         const CLIENT_WINDOW: u16 = 32_768;
         const CLIENT_MSS: u16 = 1_200;
 
-        let mut flow = server_flow(local_ipv4(), LISTEN_PORT);
+        let mut flow = server_flow(local_ipv4(), LISTEN_PORT, None);
         let mut context = PacketContext::new();
         let syn = syn_to_server(
             CLIENT_ISS,
@@ -926,7 +941,7 @@ mod tests {
         const CLIENT_PORT: u16 = 49_153;
         const LISTEN_PORT: u16 = 8080;
 
-        let mut flow = server_flow(local_ipv4(), LISTEN_PORT);
+        let mut flow = server_flow(local_ipv4(), LISTEN_PORT, None);
         let mut context = PacketContext::new();
         let syn = syn_to_server(CLIENT_ISS, CLIENT_PORT, LISTEN_PORT, TCP_WINDOW, TCP_MSS);
 
@@ -995,7 +1010,7 @@ mod tests {
         const LISTEN_PORT: u16 = 8080;
 
         let payload = b"client request";
-        let mut flow = server_flow(local_ipv4(), LISTEN_PORT);
+        let mut flow = server_flow(local_ipv4(), LISTEN_PORT, None);
         let mut context = tcp_context();
         context.set_tcp_local_port(LISTEN_PORT);
         context.set_tcp_remote_port(CLIENT_PORT);
@@ -1043,6 +1058,51 @@ mod tests {
         assert_eq!(tcp.sequence_number_value(), SND_NXT);
         assert_eq!(tcp.acknowledgment_number_value(), expected_rcv_nxt);
         assert_eq!(tcp.flags_value(), TCP_FLAG_ACK);
+        assert_eq!(step.target(), None);
+        assert!(step.expects_reply());
+    }
+
+    #[test]
+    fn tcp_server_established_transition_sends_configured_response_and_advances_snd_nxt() {
+        const CLIENT_PORT: u16 = 49_153;
+        const LISTEN_PORT: u16 = 8080;
+
+        let request = b"client request";
+        let response = b"server response".to_vec();
+        let mut flow = server_flow(local_ipv4(), LISTEN_PORT, Some(response.clone()));
+        let mut context = tcp_context();
+        context.set_tcp_local_port(LISTEN_PORT);
+        context.set_tcp_remote_port(CLIENT_PORT);
+        context.set_tcp_remote_ipv4(remote_ipv4());
+
+        let client_data = data_to_server(RCV_NXT, SND_NXT, CLIENT_PORT, LISTEN_PORT, request);
+        let step = flow
+            .state_mut(ESTABLISHED)
+            .expect("Established state exists")
+            .find_transition(&client_data, &context)
+            .expect("client data transition matches")
+            .fire(&client_data, &mut context)
+            .expect("client data transition should fire");
+        let packet = step
+            .outgoing()
+            .expect("client data transition sends configured response");
+        let decoded = compiled_ipv4(packet.clone());
+        let tcp = decoded.layer::<crafter::Tcp>().expect("TCP layer");
+        let raw = decoded.layer::<crafter::Raw>().expect("Raw payload");
+        let expected_rcv_nxt = RCV_NXT.wrapping_add(request.len() as u32);
+
+        assert_eq!(context.tcp_received_payload(), request);
+        assert_eq!(context.get_tcp_rcv_nxt(), Some(expected_rcv_nxt));
+        assert_eq!(
+            context.get_tcp_snd_nxt(),
+            Some(SND_NXT.wrapping_add(response.len() as u32))
+        );
+        assert_eq!(tcp.source_port_value(), LISTEN_PORT);
+        assert_eq!(tcp.destination_port_value(), CLIENT_PORT);
+        assert_eq!(tcp.sequence_number_value(), SND_NXT);
+        assert_eq!(tcp.acknowledgment_number_value(), expected_rcv_nxt);
+        assert_eq!(tcp.flags_value(), TCP_FLAG_PSH | TCP_FLAG_ACK);
+        assert_eq!(raw.as_bytes(), response.as_slice());
         assert_eq!(step.target(), None);
         assert!(step.expects_reply());
     }

--- a/tools/flow/src/flows/tcp.rs
+++ b/tools/flow/src/flows/tcp.rs
@@ -11,6 +11,8 @@ use crate::{Flow, FlowBuilderExt, FlowState, PacketContext, Role, Step};
 
 const TCP_WINDOW: u16 = 64_240;
 const TCP_MSS: u16 = 1_460;
+const TCP_CLIENT_ISS: u32 = 0x1020_3040;
+const TCP_CLIENT_LOCAL_PORT: u16 = 49_152;
 
 /// Initial client state: active open has sent or will send SYN.
 pub const SYN_SENT: &str = "SynSent";
@@ -195,17 +197,17 @@ fn fin_segment(
 
 /// Build the TCP client flow scaffold.
 ///
-/// The address, port, and payload arguments are placeholders for the real TCP
-/// actions added by later steps. This scaffold only declares the lifecycle.
+/// The client starts with an active-open SYN. Later steps add the reply
+/// transitions and payload handling for the rest of the lifecycle.
 pub fn client_flow(
-    _local_ip: Ipv4Addr,
-    _remote_ip: Ipv4Addr,
-    _remote_port: u16,
+    local_ip: Ipv4Addr,
+    remote_ip: Ipv4Addr,
+    remote_port: u16,
     _payload: Option<Vec<u8>>,
 ) -> Flow {
     Flow::new("tcp-client")
         .role(Role::Initiator)
-        .state(stub_state(SYN_SENT, ESTABLISHED))
+        .state(client_syn_sent_state(local_ip, remote_ip, remote_port))
         .state(stub_state(ESTABLISHED, FIN_WAIT_1))
         .state(stub_state(FIN_WAIT_1, FIN_WAIT_2))
         .state(stub_state(FIN_WAIT_2, CLOSED))
@@ -227,6 +229,30 @@ pub fn server_flow(_local_ip: Ipv4Addr, _listen_port: u16) -> Flow {
         .state(stub_state(LAST_ACK, CLOSED_SRV))
         .state(terminal_state(CLOSED_SRV))
         .initial(LISTEN)
+}
+
+fn client_syn_sent_state(local_ip: Ipv4Addr, remote_ip: Ipv4Addr, remote_port: u16) -> FlowState {
+    FlowState::new(SYN_SENT)
+        .on_entry(move |ctx| {
+            let iss = TCP_CLIENT_ISS;
+
+            ctx.set_tcp_iss(iss);
+            ctx.set_tcp_snd_nxt(iss.wrapping_add(1));
+            ctx.set_tcp_local_port(TCP_CLIENT_LOCAL_PORT);
+            ctx.set_tcp_remote_port(remote_port);
+            ctx.set_tcp_remote_ipv4(remote_ip);
+
+            let syn = syn_segment(
+                ctx,
+                local_ip,
+                TCP_CLIENT_LOCAL_PORT,
+                remote_ip,
+                remote_port,
+            );
+
+            Ok(Step::send(syn))
+        })
+        .entry_description("TCP SYN")
 }
 
 fn stub_state(name: &'static str, next: &'static str) -> FlowState {
@@ -282,7 +308,7 @@ mod tests {
     use super::{
         ack_segment, client_flow, data_segment, fin_segment, server_flow, syn_ack_segment,
         syn_segment, CLOSED, CLOSED_SRV, CLOSE_WAIT, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, LAST_ACK,
-        LISTEN, SYN_RECEIVED, SYN_SENT, TCP_MSS, TCP_WINDOW,
+        LISTEN, SYN_RECEIVED, SYN_SENT, TCP_CLIENT_ISS, TCP_CLIENT_LOCAL_PORT, TCP_MSS, TCP_WINDOW,
     };
     use std::net::Ipv4Addr;
 
@@ -334,6 +360,40 @@ mod tests {
             ],
         );
         flow.validate().expect("TCP server scaffold is valid");
+    }
+
+    #[test]
+    fn tcp_client_syn_sent_entry_sends_syn_and_records_initial_state() {
+        let mut flow = client_flow(local_ipv4(), remote_ipv4(), REMOTE_PORT, None);
+        let mut context = PacketContext::new();
+
+        let step = flow
+            .state_mut(SYN_SENT)
+            .expect("SynSent state exists")
+            .run_entry(&mut context)
+            .expect("SynSent entry should run")
+            .expect("SynSent entry should return a step");
+        let packet = step.outgoing().expect("SynSent entry sends SYN");
+        let ipv4 = packet.layer::<crafter::Ipv4>().expect("IPv4 layer");
+        let tcp = packet.layer::<crafter::Tcp>().expect("TCP layer");
+
+        assert_eq!(step.target(), None);
+        assert!(step.expects_reply());
+        assert_eq!(ipv4.source(), local_ipv4());
+        assert_eq!(ipv4.destination(), remote_ipv4());
+        assert_eq!(tcp.source_port_value(), TCP_CLIENT_LOCAL_PORT);
+        assert_eq!(tcp.destination_port_value(), REMOTE_PORT);
+        assert_eq!(tcp.sequence_number_value(), TCP_CLIENT_ISS);
+        assert_eq!(tcp.flags_value(), TCP_FLAG_SYN);
+        assert_has_mss(tcp);
+        assert_eq!(context.get_tcp_iss(), Some(TCP_CLIENT_ISS));
+        assert_eq!(
+            context.get_tcp_snd_nxt(),
+            Some(TCP_CLIENT_ISS.wrapping_add(1))
+        );
+        assert_eq!(context.get_tcp_local_port(), Some(TCP_CLIENT_LOCAL_PORT));
+        assert_eq!(context.get_tcp_remote_port(), Some(REMOTE_PORT));
+        assert_eq!(context.get_tcp_remote_ipv4(), Some(remote_ipv4()));
     }
 
     fn assert_named_states(flow: &crate::Flow, expected: &[&str]) {

--- a/tools/flow/src/lib.rs
+++ b/tools/flow/src/lib.rs
@@ -34,7 +34,7 @@ pub use error::{FlowError, Result};
 pub use flow::{Flow, FlowBuilderExt};
 pub use matcher::{Matcher, PredicateMatcher};
 pub use mutator::{FnMutator, Identity, Mutator};
-pub use options::{RunOptions, SendRepeat};
+pub use options::{RetransmitPolicy, RunOptions, SendRepeat};
 pub use report::{FlowOutcome, FlowReport};
 pub use role::Role;
 pub use runner::Runner;

--- a/tools/flow/src/matcher/mod.rs
+++ b/tools/flow/src/matcher/mod.rs
@@ -5,10 +5,12 @@ use crate::PacketContext;
 mod combinators;
 mod layer;
 mod reply;
+mod tcp;
 
 pub use combinators::{all, any, not, And, MatcherExt, Not, Or};
 pub use layer::LayerMatcher;
 pub use reply::ReplyMatcher;
+pub use tcp::{tcp_segment, tcp_segment_for_ipv4, TcpSegmentMatcher};
 
 type PacketPredicate = dyn Fn(&crafter::Packet, &PacketContext) -> bool;
 

--- a/tools/flow/src/matcher/tcp.rs
+++ b/tools/flow/src/matcher/tcp.rs
@@ -104,9 +104,7 @@ impl Matcher for TcpSegmentMatcher {
         }
 
         match &self.ack_predicate {
-            Some(predicate) => {
-                (predicate.predicate)(tcp.acknowledgment_number_value(), ctx)
-            }
+            Some(predicate) => (predicate.predicate)(tcp.acknowledgment_number_value(), ctx),
             None => true,
         }
     }
@@ -117,8 +115,12 @@ impl Matcher for TcpSegmentMatcher {
             None => format!("*:{}", self.local_port),
         };
         let mut description = format!(
-            "tcp segment {}:{} -> {} flags include 0x{:03x}",
-            self.remote_ipv4, self.remote_port, local, self.required_flags
+            "tcp segment {}:{} -> {} flags include 0x{:03x} ({})",
+            self.remote_ipv4,
+            self.remote_port,
+            local,
+            self.required_flags,
+            flag_names(self.required_flags),
         );
 
         if let Some(predicate) = &self.ack_predicate {
@@ -127,6 +129,41 @@ impl Matcher for TcpSegmentMatcher {
         }
 
         description
+    }
+}
+
+fn flag_names(flags: u16) -> String {
+    let known_flags = [
+        (crafter::TCP_FLAG_FIN, "FIN"),
+        (crafter::TCP_FLAG_SYN, "SYN"),
+        (crafter::TCP_FLAG_RST, "RST"),
+        (crafter::TCP_FLAG_PSH, "PSH"),
+        (crafter::TCP_FLAG_ACK, "ACK"),
+        (crafter::TCP_FLAG_URG, "URG"),
+        (crafter::TCP_FLAG_ECE, "ECE"),
+        (crafter::TCP_FLAG_CWR, "CWR"),
+        (crafter::TCP_FLAG_NS, "NS"),
+        (crafter::TCP_FLAG_AE, "AE"),
+    ];
+    let mut names = Vec::new();
+    let mut known_bits = 0;
+
+    for (flag, name) in known_flags {
+        known_bits |= flag;
+        if flags & flag != 0 {
+            names.push(name.to_string());
+        }
+    }
+
+    let unknown_bits = flags & !known_bits;
+    if unknown_bits != 0 {
+        names.push(format!("0x{unknown_bits:03x}"));
+    }
+
+    if names.is_empty() {
+        "none".to_string()
+    } else {
+        names.join("|")
     }
 }
 
@@ -219,6 +256,7 @@ mod tests {
 
         assert!(matcher.matches(&packet, &context));
         assert!(matcher.describe().contains("flags include 0x012"));
+        assert!(matcher.describe().contains("(SYN|ACK)"));
     }
 
     #[test]

--- a/tools/flow/src/matcher/tcp.rs
+++ b/tools/flow/src/matcher/tcp.rs
@@ -1,0 +1,291 @@
+use std::net::Ipv4Addr;
+
+use crate::{Matcher, PacketContext};
+
+type AckPredicate = dyn Fn(u32, &PacketContext) -> bool;
+
+struct TcpAckPredicate {
+    description: String,
+    predicate: Box<AckPredicate>,
+}
+
+/// Matcher for TCP segments from a specific peer connection.
+///
+/// The matcher checks the reversed TCP port pair, the remote IPv4 address, the
+/// required TCP flag bits, and optionally the local IPv4 destination and ACK
+/// number.
+pub struct TcpSegmentMatcher {
+    local_ipv4: Option<Ipv4Addr>,
+    local_port: u16,
+    remote_ipv4: Ipv4Addr,
+    remote_port: u16,
+    required_flags: u16,
+    ack_predicate: Option<TcpAckPredicate>,
+}
+
+impl TcpSegmentMatcher {
+    /// Create a matcher for a TCP segment from `remote_ipv4:remote_port` to the
+    /// local port.
+    pub fn new(
+        local_port: u16,
+        remote_port: u16,
+        remote_ipv4: Ipv4Addr,
+        required_flags: u16,
+    ) -> Self {
+        Self {
+            local_ipv4: None,
+            local_port,
+            remote_ipv4,
+            remote_port,
+            required_flags,
+            ack_predicate: None,
+        }
+    }
+
+    /// Require the IPv4 destination address to match the local endpoint.
+    pub fn local_ipv4(mut self, local_ipv4: Ipv4Addr) -> Self {
+        self.local_ipv4 = Some(local_ipv4);
+        self
+    }
+
+    /// Require an exact TCP acknowledgement number.
+    pub fn ack_number(self, expected_ack: u32) -> Self {
+        self.ack_where(format!("ack == 0x{expected_ack:08x}"), move |ack, _ctx| {
+            ack == expected_ack
+        })
+    }
+
+    /// Require the TCP acknowledgement number to equal `PacketContext`'s
+    /// `tcp_snd_nxt` value.
+    pub fn ack_matches_tcp_snd_nxt(self) -> Self {
+        self.ack_where("ack == tcp_snd_nxt", |ack, ctx| {
+            ctx.get_tcp_snd_nxt() == Some(ack)
+        })
+    }
+
+    /// Require the TCP acknowledgement number to satisfy `predicate`.
+    pub fn ack_where(
+        mut self,
+        description: impl Into<String>,
+        predicate: impl Fn(u32, &PacketContext) -> bool + 'static,
+    ) -> Self {
+        self.ack_predicate = Some(TcpAckPredicate {
+            description: description.into(),
+            predicate: Box::new(predicate),
+        });
+        self
+    }
+}
+
+impl Matcher for TcpSegmentMatcher {
+    fn matches(&self, packet: &crafter::Packet, ctx: &PacketContext) -> bool {
+        let Some(ipv4) = packet.layer::<crafter::Ipv4>() else {
+            return false;
+        };
+        if ipv4.source() != self.remote_ipv4 {
+            return false;
+        }
+        if let Some(local_ipv4) = self.local_ipv4 {
+            if ipv4.destination() != local_ipv4 {
+                return false;
+            }
+        }
+
+        let Some(tcp) = packet.layer::<crafter::Tcp>() else {
+            return false;
+        };
+        if tcp.source_port_value() != self.remote_port
+            || tcp.destination_port_value() != self.local_port
+        {
+            return false;
+        }
+        if tcp.flags_value() & self.required_flags != self.required_flags {
+            return false;
+        }
+
+        match &self.ack_predicate {
+            Some(predicate) => {
+                (predicate.predicate)(tcp.acknowledgment_number_value(), ctx)
+            }
+            None => true,
+        }
+    }
+
+    fn describe(&self) -> String {
+        let local = match self.local_ipv4 {
+            Some(local_ipv4) => format!("{local_ipv4}:{}", self.local_port),
+            None => format!("*:{}", self.local_port),
+        };
+        let mut description = format!(
+            "tcp segment {}:{} -> {} flags include 0x{:03x}",
+            self.remote_ipv4, self.remote_port, local, self.required_flags
+        );
+
+        if let Some(predicate) = &self.ack_predicate {
+            description.push_str(" and ");
+            description.push_str(&predicate.description);
+        }
+
+        description
+    }
+}
+
+/// Create a matcher for a TCP segment from `remote_ipv4:remote_port` to
+/// `local_port`.
+pub fn tcp_segment(
+    local_port: u16,
+    remote_port: u16,
+    remote_ipv4: Ipv4Addr,
+    required_flags: u16,
+) -> TcpSegmentMatcher {
+    TcpSegmentMatcher::new(local_port, remote_port, remote_ipv4, required_flags)
+}
+
+/// Create a matcher for a TCP segment with the full reversed IPv4 four-tuple.
+pub fn tcp_segment_for_ipv4(
+    local_ipv4: Ipv4Addr,
+    local_port: u16,
+    remote_ipv4: Ipv4Addr,
+    remote_port: u16,
+    required_flags: u16,
+) -> TcpSegmentMatcher {
+    tcp_segment(local_port, remote_port, remote_ipv4, required_flags).local_ipv4(local_ipv4)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use crafter::{NetworkLayer, Packet, TCP_FLAG_ACK, TCP_FLAG_SYN};
+
+    use super::{tcp_segment_for_ipv4, TcpSegmentMatcher};
+    use crate::{Matcher, PacketContext};
+
+    const LOCAL_PORT: u16 = 49_152;
+    const REMOTE_PORT: u16 = 443;
+    const ACK_NUMBER: u32 = 0x0102_0304;
+
+    fn local_ipv4() -> Ipv4Addr {
+        Ipv4Addr::new(192, 0, 2, 10)
+    }
+
+    fn remote_ipv4() -> Ipv4Addr {
+        Ipv4Addr::new(198, 51, 100, 20)
+    }
+
+    fn decoded_tcp_packet(
+        source: Ipv4Addr,
+        destination: Ipv4Addr,
+        source_port: u16,
+        destination_port: u16,
+        flags: u16,
+        ack: u32,
+    ) -> Packet {
+        let packet = crafter::Ipv4::new().src(source).dst(destination)
+            / crafter::Tcp::new()
+                .sport(source_port)
+                .dport(destination_port)
+                .seq(0x1112_1314)
+                .ack(ack)
+                .flags(flags);
+        let compiled = packet.compile().expect("tcp packet should compile");
+
+        Packet::decode_from_l3(NetworkLayer::Ipv4, compiled.as_bytes())
+            .expect("tcp packet should decode")
+    }
+
+    fn syn_ack_matcher() -> TcpSegmentMatcher {
+        tcp_segment_for_ipv4(
+            local_ipv4(),
+            LOCAL_PORT,
+            remote_ipv4(),
+            REMOTE_PORT,
+            TCP_FLAG_SYN | TCP_FLAG_ACK,
+        )
+    }
+
+    #[test]
+    fn tcp_segment_matcher_accepts_syn_ack_for_connection() {
+        let matcher = syn_ack_matcher();
+        let packet = decoded_tcp_packet(
+            remote_ipv4(),
+            local_ipv4(),
+            REMOTE_PORT,
+            LOCAL_PORT,
+            TCP_FLAG_SYN | TCP_FLAG_ACK,
+            ACK_NUMBER,
+        );
+        let context = PacketContext::new();
+
+        assert!(matcher.matches(&packet, &context));
+        assert!(matcher.describe().contains("flags include 0x012"));
+    }
+
+    #[test]
+    fn tcp_segment_matcher_rejects_different_port() {
+        let matcher = syn_ack_matcher();
+        let wrong_port = decoded_tcp_packet(
+            remote_ipv4(),
+            local_ipv4(),
+            REMOTE_PORT + 1,
+            LOCAL_PORT,
+            TCP_FLAG_SYN | TCP_FLAG_ACK,
+            ACK_NUMBER,
+        );
+        let context = PacketContext::new();
+
+        assert!(!matcher.matches(&wrong_port, &context));
+    }
+
+    #[test]
+    fn tcp_segment_matcher_rejects_plain_ack_when_syn_ack_required() {
+        let matcher = syn_ack_matcher();
+        let plain_ack = decoded_tcp_packet(
+            remote_ipv4(),
+            local_ipv4(),
+            REMOTE_PORT,
+            LOCAL_PORT,
+            TCP_FLAG_ACK,
+            ACK_NUMBER,
+        );
+        let context = PacketContext::new();
+
+        assert!(!matcher.matches(&plain_ack, &context));
+    }
+
+    #[test]
+    fn tcp_segment_matcher_can_require_ack_number() {
+        let matcher = syn_ack_matcher().ack_number(ACK_NUMBER);
+        let wrong_ack_matcher = syn_ack_matcher().ack_number(ACK_NUMBER + 1);
+        let packet = decoded_tcp_packet(
+            remote_ipv4(),
+            local_ipv4(),
+            REMOTE_PORT,
+            LOCAL_PORT,
+            TCP_FLAG_SYN | TCP_FLAG_ACK,
+            ACK_NUMBER,
+        );
+        let context = PacketContext::new();
+
+        assert!(matcher.matches(&packet, &context));
+        assert!(!wrong_ack_matcher.matches(&packet, &context));
+    }
+
+    #[test]
+    fn tcp_segment_matcher_can_compare_ack_to_context_send_next() {
+        let matcher = syn_ack_matcher().ack_matches_tcp_snd_nxt();
+        let packet = decoded_tcp_packet(
+            remote_ipv4(),
+            local_ipv4(),
+            REMOTE_PORT,
+            LOCAL_PORT,
+            TCP_FLAG_SYN | TCP_FLAG_ACK,
+            ACK_NUMBER,
+        );
+        let mut context = PacketContext::new();
+
+        assert!(!matcher.matches(&packet, &context));
+        context.set_tcp_snd_nxt(ACK_NUMBER);
+        assert!(matcher.matches(&packet, &context));
+    }
+}

--- a/tools/flow/src/options.rs
+++ b/tools/flow/src/options.rs
@@ -37,6 +37,30 @@ impl Default for SendRepeat {
     }
 }
 
+/// Bounded retransmit policy for an outstanding segment awaiting a reply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetransmitPolicy {
+    count: u32,
+    interval: Duration,
+}
+
+impl RetransmitPolicy {
+    /// Create a policy with `count` re-sends after the initial send.
+    pub const fn new(count: u32, interval: Duration) -> Self {
+        Self { count, interval }
+    }
+
+    /// Number of re-sends after the initial outgoing segment.
+    pub const fn count(self) -> u32 {
+        self.count
+    }
+
+    /// Delay before each re-send.
+    pub const fn interval(self) -> Duration {
+        self.interval
+    }
+}
+
 /// Bundles the binding, loop bound, timeout, and retry knobs for one run.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RunOptions {
@@ -45,6 +69,7 @@ pub struct RunOptions {
     pub step_timeout: Duration,
     pub run_timeout: Option<Duration>,
     pub send_repeat: SendRepeat,
+    pub retransmit: Option<RetransmitPolicy>,
     pub retries: u32,
     pub capture_filter: Option<String>,
 }
@@ -80,6 +105,18 @@ impl RunOptions {
         self
     }
 
+    /// Re-send an outstanding segment up to `count` times when a receive step times out.
+    pub fn retransmit(mut self, count: u32, interval: Duration) -> Self {
+        self.retransmit = Some(RetransmitPolicy::new(count, interval));
+        self
+    }
+
+    /// Disable outstanding-segment retransmission.
+    pub fn clear_retransmit(mut self) -> Self {
+        self.retransmit = None;
+        self
+    }
+
     /// Set the number of retry attempts.
     pub fn retries(mut self, retries: u32) -> Self {
         self.retries = retries;
@@ -111,6 +148,7 @@ impl Default for RunOptions {
             step_timeout: Duration::from_millis(250),
             run_timeout: None,
             send_repeat: SendRepeat::default(),
+            retransmit: None,
             retries: 1,
             capture_filter: None,
         }
@@ -128,7 +166,7 @@ fn normalize_capture_filter(capture_filter: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{RunOptions, SendRepeat};
+    use super::{RetransmitPolicy, RunOptions, SendRepeat};
     use crate::{Binding, Bound};
     use std::time::Duration;
 
@@ -141,6 +179,7 @@ mod tests {
         assert_eq!(options.step_timeout, Duration::from_millis(250));
         assert_eq!(options.run_timeout, None);
         assert_eq!(options.send_repeat, SendRepeat::default());
+        assert_eq!(options.retransmit, None);
         assert_eq!(options.retries, 1);
         assert_eq!(options.capture_filter, None);
     }
@@ -191,6 +230,25 @@ mod tests {
         let repeat = SendRepeat::new(0, Duration::from_millis(1));
 
         assert_eq!(repeat.count(), 1);
+    }
+
+    #[test]
+    fn run_options_builder_updates_retransmit() {
+        let interval = Duration::from_millis(25);
+        let options = RunOptions::default().retransmit(2, interval);
+
+        assert_eq!(options.retransmit, Some(RetransmitPolicy::new(2, interval)));
+        assert_eq!(options.retransmit.unwrap().count(), 2);
+        assert_eq!(options.retransmit.unwrap().interval(), interval);
+    }
+
+    #[test]
+    fn run_options_builder_clears_retransmit() {
+        let options = RunOptions::default()
+            .retransmit(2, Duration::from_millis(25))
+            .clear_retransmit();
+
+        assert_eq!(options.retransmit, None);
     }
 
     #[test]

--- a/tools/flow/src/prelude.rs
+++ b/tools/flow/src/prelude.rs
@@ -25,7 +25,7 @@ pub use crate::Runner;
 pub use crate::{run_tool, ToolRun, ToolRunReport};
 pub use crate::{Flow, FlowBuilderExt};
 pub use crate::{FlowState, FnMutator, Identity, Mutator, Step, StepGotoExt, Transition};
-pub use crate::{RunOptions, SendRepeat};
+pub use crate::{RetransmitPolicy, RunOptions, SendRepeat};
 
 #[cfg(test)]
 mod tests {

--- a/tools/flow/src/prelude.rs
+++ b/tools/flow/src/prelude.rs
@@ -13,6 +13,10 @@ pub use crate::capture::{
 };
 pub use crate::docaddr;
 pub use crate::error::{FlowError, Result};
+pub use crate::flows::tcp::{
+    client_flow, server_flow, CLOSED, CLOSED_SRV, CLOSE_WAIT, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2,
+    LAST_ACK, LISTEN, SYN_RECEIVED, SYN_SENT,
+};
 pub use crate::matcher::{
     all, any, not, And, LayerMatcher, Matcher, MatcherExt, Not, Or, PredicateMatcher, ReplyMatcher,
 };
@@ -69,6 +73,52 @@ mod tests {
         context.set_transaction_id(7);
 
         assert_eq!(context.get_transaction_id(), Some(7));
+    }
+
+    #[test]
+    fn prelude_exports_tcp_flows_and_context_helpers() {
+        use crafter_flow::prelude::*;
+        use std::net::Ipv4Addr;
+
+        let _client_flow: fn(Ipv4Addr, Ipv4Addr, u16, Option<Vec<u8>>) -> Flow = client_flow;
+        let _server_flow: fn(Ipv4Addr, u16, Option<Vec<u8>>) -> Flow = server_flow;
+        let states = [
+            SYN_SENT,
+            ESTABLISHED,
+            FIN_WAIT_1,
+            FIN_WAIT_2,
+            CLOSED,
+            LISTEN,
+            SYN_RECEIVED,
+            CLOSE_WAIT,
+            LAST_ACK,
+            CLOSED_SRV,
+        ];
+        assert!(states.contains(&SYN_SENT));
+
+        let mut context = PacketContext::new();
+        context.set_tcp_snd_nxt(1);
+        context.set_tcp_rcv_nxt(2);
+        context.set_tcp_iss(3);
+        context.set_tcp_local_port(49_152);
+        context.set_tcp_remote_port(443);
+        context.set_tcp_remote_ipv4(Ipv4Addr::new(198, 51, 100, 20));
+        context.set_tcp_peer_mss(1_460);
+        context.set_tcp_peer_window(32_768);
+        context.append_tcp_payload(b"tcp");
+
+        assert_eq!(context.get_tcp_snd_nxt(), Some(1));
+        assert_eq!(context.get_tcp_rcv_nxt(), Some(2));
+        assert_eq!(context.get_tcp_iss(), Some(3));
+        assert_eq!(context.get_tcp_local_port(), Some(49_152));
+        assert_eq!(context.get_tcp_remote_port(), Some(443));
+        assert_eq!(
+            context.get_tcp_remote_ipv4(),
+            Some(Ipv4Addr::new(198, 51, 100, 20))
+        );
+        assert_eq!(context.get_tcp_peer_mss(), Some(1_460));
+        assert_eq!(context.get_tcp_peer_window(), Some(32_768));
+        assert_eq!(context.tcp_received_payload(), b"tcp");
     }
 
     #[test]

--- a/tools/flow/src/report.rs
+++ b/tools/flow/src/report.rs
@@ -104,6 +104,11 @@ impl FlowReport {
         &self.visited_states
     }
 
+    /// Return the final state name recorded by the runner.
+    pub fn final_state(&self) -> Option<&str> {
+        self.visited_states.last().map(String::as_str)
+    }
+
     /// Return the number of packets sent or planned.
     pub const fn sent_count(&self) -> usize {
         self.sent_count
@@ -157,12 +162,13 @@ impl FlowReport {
     /// Return a compact one-line description of this run.
     pub fn summary(&self) -> String {
         format!(
-            "FlowReport '{}' ({:?}, dry_run={}): {:?}, states={}, sent={}, received={}, bytes_sent={}, bytes_received={}, transitions={}, iterations={}, elapsed={:?}",
+            "FlowReport '{}' ({:?}, dry_run={}): {:?}, state_trace={}, final_state={}, sent={}, received={}, bytes_sent={}, bytes_received={}, transitions={}, iterations={}, elapsed={:?}",
             self.flow_name,
             self.role,
             self.dry_run,
             self.outcome,
-            self.visited_states.len(),
+            self.state_trace(),
+            self.final_state().unwrap_or("none"),
             self.sent_count,
             self.received_count,
             self.bytes_sent,
@@ -193,6 +199,14 @@ impl FlowReport {
             "  payload bytes: sent={}, received={}",
             self.bytes_sent, self.bytes_received
         );
+        let _ = writeln!(
+            output,
+            "  state trace: {} (final={}, bytes_sent={}, bytes_received={})",
+            self.state_trace(),
+            self.final_state().unwrap_or("none"),
+            self.bytes_sent,
+            self.bytes_received
+        );
         let _ = writeln!(output, "  visited states:");
         if self.visited_states.is_empty() {
             let _ = writeln!(output, "    none");
@@ -212,6 +226,14 @@ impl FlowReport {
         let _ = writeln!(output, "  context: {}", self.context_snapshot);
 
         output
+    }
+
+    fn state_trace(&self) -> String {
+        if self.visited_states.is_empty() {
+            "none".to_string()
+        } else {
+            self.visited_states.join(" -> ")
+        }
     }
 
     /// Return a compact JSON artifact for this run.
@@ -335,6 +357,7 @@ mod tests {
         assert_eq!(report.bytes_sent(), 0);
         assert_eq!(report.bytes_received(), 0);
         assert_eq!(report.received_payload(), b"");
+        assert_eq!(report.final_state(), Some("Done"));
         assert_eq!(report.transitions_taken(), &["reply packet".to_string()]);
         assert_eq!(report.iterations(), 1);
         assert_eq!(report.elapsed(), Duration::from_millis(7));
@@ -345,9 +368,14 @@ mod tests {
         );
         assert!(report.summary().contains("example-flow"));
         assert!(report.summary().contains("dry_run=true"));
+        assert!(report.summary().contains("state_trace=Start -> Done"));
+        assert!(report.summary().contains("final_state=Done"));
         assert!(report.summary().contains("bytes_sent=0"));
         assert!(report.show().contains("dry-run: true"));
         assert!(report.show().contains("payload bytes: sent=0, received=0"));
+        assert!(report
+            .show()
+            .contains("state trace: Start -> Done (final=Done"));
         assert!(report.show().contains("reply packet"));
     }
 
@@ -371,6 +399,7 @@ mod tests {
         assert_eq!(report.bytes_sent(), 12);
         assert_eq!(report.bytes_received(), 10);
         assert_eq!(report.received_payload(), b"peer-bytes");
+        assert_eq!(report.final_state(), Some("Established"));
         assert!(report.summary().contains("bytes_sent=12"));
         assert!(report.summary().contains("bytes_received=10"));
         assert!(report

--- a/tools/flow/src/report.rs
+++ b/tools/flow/src/report.rs
@@ -27,6 +27,9 @@ pub struct FlowReport {
     visited_states: Vec<String>,
     sent_count: usize,
     received_count: usize,
+    bytes_sent: usize,
+    bytes_received: usize,
+    received_payload: Vec<u8>,
     transitions_taken: Vec<String>,
     iterations: u64,
     elapsed: Duration,
@@ -57,12 +60,28 @@ impl FlowReport {
             visited_states,
             sent_count,
             received_count,
+            bytes_sent: 0,
+            bytes_received: 0,
+            received_payload: Vec::new(),
             transitions_taken,
             iterations,
             elapsed,
             outcome,
             context_snapshot: context_snapshot.into(),
         }
+    }
+
+    /// Return a report with TCP payload byte counters attached.
+    pub fn with_tcp_payload(
+        mut self,
+        bytes_sent: usize,
+        received_payload: impl Into<Vec<u8>>,
+    ) -> Self {
+        let received_payload = received_payload.into();
+        self.bytes_sent = bytes_sent;
+        self.bytes_received = received_payload.len();
+        self.received_payload = received_payload;
+        self
     }
 
     /// Return the executed flow name.
@@ -95,6 +114,21 @@ impl FlowReport {
         self.received_count
     }
 
+    /// Return TCP payload bytes sent by this run.
+    pub const fn bytes_sent(&self) -> usize {
+        self.bytes_sent
+    }
+
+    /// Return TCP payload bytes received by this run.
+    pub const fn bytes_received(&self) -> usize {
+        self.bytes_received
+    }
+
+    /// Return received TCP payload accumulated by this run.
+    pub fn received_payload(&self) -> &[u8] {
+        &self.received_payload
+    }
+
     /// Return transition descriptions in the order they fired.
     pub fn transitions_taken(&self) -> &[String] {
         &self.transitions_taken
@@ -123,7 +157,7 @@ impl FlowReport {
     /// Return a compact one-line description of this run.
     pub fn summary(&self) -> String {
         format!(
-            "FlowReport '{}' ({:?}, dry_run={}): {:?}, states={}, sent={}, received={}, transitions={}, iterations={}, elapsed={:?}",
+            "FlowReport '{}' ({:?}, dry_run={}): {:?}, states={}, sent={}, received={}, bytes_sent={}, bytes_received={}, transitions={}, iterations={}, elapsed={:?}",
             self.flow_name,
             self.role,
             self.dry_run,
@@ -131,6 +165,8 @@ impl FlowReport {
             self.visited_states.len(),
             self.sent_count,
             self.received_count,
+            self.bytes_sent,
+            self.bytes_received,
             self.transitions_taken.len(),
             self.iterations,
             self.elapsed,
@@ -151,6 +187,11 @@ impl FlowReport {
             output,
             "  packets: sent={}, received={}",
             self.sent_count, self.received_count
+        );
+        let _ = writeln!(
+            output,
+            "  payload bytes: sent={}, received={}",
+            self.bytes_sent, self.bytes_received
         );
         let _ = writeln!(output, "  visited states:");
         if self.visited_states.is_empty() {
@@ -291,6 +332,9 @@ mod tests {
         );
         assert_eq!(report.sent_count(), 1);
         assert_eq!(report.received_count(), 2);
+        assert_eq!(report.bytes_sent(), 0);
+        assert_eq!(report.bytes_received(), 0);
+        assert_eq!(report.received_payload(), b"");
         assert_eq!(report.transitions_taken(), &["reply packet".to_string()]);
         assert_eq!(report.iterations(), 1);
         assert_eq!(report.elapsed(), Duration::from_millis(7));
@@ -301,8 +345,37 @@ mod tests {
         );
         assert!(report.summary().contains("example-flow"));
         assert!(report.summary().contains("dry_run=true"));
+        assert!(report.summary().contains("bytes_sent=0"));
         assert!(report.show().contains("dry-run: true"));
+        assert!(report.show().contains("payload bytes: sent=0, received=0"));
         assert!(report.show().contains("reply packet"));
+    }
+
+    #[test]
+    fn report_reflects_tcp_payload_byte_counts() {
+        let report = FlowReport::new(
+            "payload-flow",
+            Role::Initiator,
+            true,
+            vec!["Established".to_string()],
+            1,
+            1,
+            vec!["tcp data".to_string()],
+            1,
+            Duration::from_millis(3),
+            FlowOutcome::Completed,
+            "PacketContext keys=[tcp_received_payload]",
+        )
+        .with_tcp_payload(12, b"peer-bytes".to_vec());
+
+        assert_eq!(report.bytes_sent(), 12);
+        assert_eq!(report.bytes_received(), 10);
+        assert_eq!(report.received_payload(), b"peer-bytes");
+        assert!(report.summary().contains("bytes_sent=12"));
+        assert!(report.summary().contains("bytes_received=10"));
+        assert!(report
+            .show()
+            .contains("payload bytes: sent=12, received=10"));
     }
 
     #[test]

--- a/tools/flow/src/report.rs
+++ b/tools/flow/src/report.rs
@@ -30,6 +30,8 @@ pub struct FlowReport {
     bytes_sent: usize,
     bytes_received: usize,
     received_payload: Vec<u8>,
+    tcp_snd_nxt: Option<u32>,
+    tcp_rcv_nxt: Option<u32>,
     transitions_taken: Vec<String>,
     iterations: u64,
     elapsed: Duration,
@@ -63,6 +65,8 @@ impl FlowReport {
             bytes_sent: 0,
             bytes_received: 0,
             received_payload: Vec::new(),
+            tcp_snd_nxt: None,
+            tcp_rcv_nxt: None,
             transitions_taken,
             iterations,
             elapsed,
@@ -81,6 +85,17 @@ impl FlowReport {
         self.bytes_sent = bytes_sent;
         self.bytes_received = received_payload.len();
         self.received_payload = received_payload;
+        self
+    }
+
+    /// Return a report with final TCP sequence tracking attached.
+    pub const fn with_tcp_state(
+        mut self,
+        tcp_snd_nxt: Option<u32>,
+        tcp_rcv_nxt: Option<u32>,
+    ) -> Self {
+        self.tcp_snd_nxt = tcp_snd_nxt;
+        self.tcp_rcv_nxt = tcp_rcv_nxt;
         self
     }
 
@@ -132,6 +147,16 @@ impl FlowReport {
     /// Return received TCP payload accumulated by this run.
     pub fn received_payload(&self) -> &[u8] {
         &self.received_payload
+    }
+
+    /// Return the final TCP send-next value, if this run tracked one.
+    pub const fn tcp_snd_nxt(&self) -> Option<u32> {
+        self.tcp_snd_nxt
+    }
+
+    /// Return the final TCP receive-next value, if this run tracked one.
+    pub const fn tcp_rcv_nxt(&self) -> Option<u32> {
+        self.tcp_rcv_nxt
     }
 
     /// Return transition descriptions in the order they fired.
@@ -196,9 +221,22 @@ impl FlowReport {
         );
         let _ = writeln!(
             output,
+            "  final state: {}",
+            self.final_state().unwrap_or("none")
+        );
+        let _ = writeln!(
+            output,
             "  payload bytes: sent={}, received={}",
             self.bytes_sent, self.bytes_received
         );
+        if self.tcp_snd_nxt.is_some() || self.tcp_rcv_nxt.is_some() {
+            let _ = writeln!(
+                output,
+                "  tcp state: snd_nxt={}, rcv_nxt={}",
+                format_tcp_number(self.tcp_snd_nxt),
+                format_tcp_number(self.tcp_rcv_nxt)
+            );
+        }
         let _ = writeln!(
             output,
             "  state trace: {} (final={}, bytes_sent={}, bytes_received={})",
@@ -277,6 +315,12 @@ impl FlowReport {
 
         output
     }
+}
+
+fn format_tcp_number(value: Option<u32>) -> String {
+    value
+        .map(|value| format!("0x{value:08x}"))
+        .unwrap_or_else(|| "n/a".to_string())
 }
 
 fn flow_outcome_name(outcome: &FlowOutcome) -> &'static str {
@@ -405,6 +449,41 @@ mod tests {
         assert!(report
             .show()
             .contains("payload bytes: sent=12, received=10"));
+    }
+
+    #[test]
+    fn report_show_includes_tcp_trace_counts_and_final_sequence_state() {
+        let report = FlowReport::new(
+            "tcp-client",
+            Role::Initiator,
+            true,
+            vec![
+                "SynSent".to_string(),
+                "Established".to_string(),
+                "FinWait1".to_string(),
+                "FinWait2".to_string(),
+                "Closed".to_string(),
+            ],
+            5,
+            4,
+            vec!["tcp SYN-ACK".to_string(), "tcp FIN".to_string()],
+            5,
+            Duration::from_millis(9),
+            FlowOutcome::Completed,
+            "PacketContext keys=[tcp_snd_nxt, tcp_rcv_nxt]",
+        )
+        .with_tcp_payload(17, b"server reply".to_vec())
+        .with_tcp_state(Some(0x1020_3052), Some(0x5060_708d));
+
+        let show = report.show();
+
+        assert!(show.contains("role: Initiator"));
+        assert!(
+            show.contains("state trace: SynSent -> Established -> FinWait1 -> FinWait2 -> Closed")
+        );
+        assert!(show.contains("final state: Closed"));
+        assert!(show.contains("payload bytes: sent=17, received=12"));
+        assert!(show.contains("tcp state: snd_nxt=0x10203052, rcv_nxt=0x5060708d"));
     }
 
     #[test]

--- a/tools/flow/src/runner.rs
+++ b/tools/flow/src/runner.rs
@@ -524,6 +524,7 @@ impl Runner {
             self.tcp_payload_bytes_sent,
             ctx.tcp_received_payload().to_vec(),
         )
+        .with_tcp_state(ctx.get_tcp_snd_nxt(), ctx.get_tcp_rcv_nxt())
     }
 
     fn run_timeout_elapsed(&self, elapsed: Duration) -> bool {

--- a/tools/flow/src/runner.rs
+++ b/tools/flow/src/runner.rs
@@ -529,6 +529,21 @@ mod tests {
             / crafter::Dns::a_query("example.com").id(0x1234)
     }
 
+    fn tcp_payload_packet(payload: impl AsRef<[u8]>) -> crafter::Packet {
+        crafter::Ipv4::new()
+            .src(Ipv4Addr::new(192, 0, 2, 10))
+            .dst(Ipv4Addr::new(198, 51, 100, 20))
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(49_152)
+                .dport(443)
+                .seq(0x1000)
+                .ack(0x2000)
+                .ack_segment()
+                .psh()
+            / crafter::Raw::from_bytes(payload)
+    }
+
     fn arp_frame() -> crafter::Packet {
         let sender_mac = crafter::MacAddr::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x31]);
 
@@ -1129,8 +1144,8 @@ mod tests {
 
     #[test]
     fn runner_report_completed_two_state_flow_lists_states_and_counts_sent_packets() {
-        let request = request_packet();
-        let reply = raw_packet([0xc0, 0xff, 0xee]);
+        let request = tcp_payload_packet(b"client");
+        let reply = tcp_payload_packet(b"peer");
         let expected_reply = compiled_bytes(&reply);
         let transition = Transition::on(
             PredicateMatcher::new("coffee reply", move |packet, _ctx| {
@@ -1139,7 +1154,12 @@ mod tests {
                     .map(|bytes| bytes.as_ref() == expected_reply.as_slice())
                     .unwrap_or(false)
             }),
-            |_packet, _ctx| Ok(Step::done().goto("Done")),
+            |packet, ctx| {
+                for raw in packet.layers::<crafter::Raw>() {
+                    ctx.append_tcp_payload(raw.as_bytes());
+                }
+                Ok(Step::done().goto("Done"))
+            },
         )
         .targets(["Done"])
         .terminal();
@@ -1162,7 +1182,13 @@ mod tests {
             report.visited_states(),
             &["Start".to_string(), "Done".to_string()]
         );
+        assert_eq!(report.final_state(), Some("Done"));
         assert!(report.sent_count() >= 1);
+        assert_eq!(report.bytes_sent(), 6);
+        assert_eq!(report.bytes_received(), 4);
+        assert_eq!(report.received_payload(), b"peer");
+        assert!(report.summary().contains("state_trace=Start -> Done"));
+        assert!(report.show().contains("state trace: Start -> Done"));
     }
 
     #[test]

--- a/tools/flow/src/runner.rs
+++ b/tools/flow/src/runner.rs
@@ -65,6 +65,11 @@ impl Matcher for StateTransitionsMatcher<'_> {
     }
 }
 
+struct OutstandingSegment {
+    awaiting_state: String,
+    packet: crafter::Packet,
+}
+
 /// Owns the run options and single conversation for one flow run.
 pub struct Runner {
     options: RunOptions,
@@ -72,6 +77,7 @@ pub struct Runner {
     mutator: Box<dyn Mutator>,
     send_reports: Vec<SendReport>,
     tcp_payload_bytes_sent: usize,
+    outstanding_segment: Option<OutstandingSegment>,
 }
 
 impl Runner {
@@ -140,6 +146,7 @@ impl Runner {
             mutator: Box::new(Identity),
             send_reports: Vec::new(),
             tcp_payload_bytes_sent: 0,
+            outstanding_segment: None,
         })
     }
 
@@ -275,7 +282,9 @@ impl Runner {
                 let Some(timeout) = self.effective_step_timeout(run_started) else {
                     return Ok(IterationResult::TimedOut);
                 };
-                let Some(packet) = self.conversation.recv_matching(&matcher, ctx, timeout)? else {
+                let Some(packet) =
+                    self.recv_matching_with_retransmit(&matcher, current_state, ctx, timeout)?
+                else {
                     return Ok(IterationResult::TimedOut);
                 };
                 packet
@@ -374,8 +383,16 @@ impl Runner {
         iteration: u64,
         ctx: &mut PacketContext,
     ) -> Result<StepAction> {
+        let target = step.target().map(str::to_string);
+        let entered_state = target.is_some();
+        let awaiting_state = target.clone().unwrap_or_else(|| current_state.to_string());
+        let expects_reply = step.expects_reply();
+        let is_terminal = step.is_terminal();
+        let outgoing = step.outgoing().cloned();
+
         if matches!(mode, StepMode::Active) {
-            if let Some(packet) = step.outgoing() {
+            if let Some(packet) = outgoing.as_ref() {
+                let mut last_sent = None;
                 for repeat in 0..self.options.send_repeat.count() {
                     if repeat > 0 {
                         let interval = self.options.send_repeat.interval();
@@ -385,11 +402,20 @@ impl Runner {
                     }
 
                     let packet = self.mutator.mutate(packet.clone(), iteration, ctx)?;
-                    let tcp_payload_bytes = tcp_payload_len(&packet);
-                    let report = self.conversation.send(&packet)?;
-                    self.tcp_payload_bytes_sent += tcp_payload_bytes;
-                    self.send_reports.push(report);
+                    self.send_packet(&packet)?;
+                    last_sent = Some(packet);
                 }
+
+                self.outstanding_segment = if expects_reply {
+                    last_sent.map(|packet| OutstandingSegment {
+                        awaiting_state,
+                        packet,
+                    })
+                } else {
+                    None
+                };
+            } else if target.is_some() || is_terminal {
+                self.outstanding_segment = None;
             }
         }
 
@@ -397,13 +423,11 @@ impl Runner {
             return Ok(StepAction::Settled);
         }
 
-        let target = step.target().map(str::to_string);
-        let entered_state = target.is_some();
         if let Some(target) = target.as_deref() {
             Self::ensure_state(flow, target)?;
         }
 
-        if step.is_terminal() {
+        if is_terminal {
             let state = target.unwrap_or_else(|| current_state.to_string());
             return Ok(StepAction::Terminal(TerminalStep {
                 state,
@@ -415,6 +439,63 @@ impl Runner {
             Some(target) => Ok(StepAction::Enter(target)),
             None => Ok(StepAction::Settled),
         }
+    }
+
+    fn recv_matching_with_retransmit(
+        &mut self,
+        matcher: &dyn Matcher,
+        current_state: &str,
+        ctx: &PacketContext,
+        timeout: Duration,
+    ) -> Result<Option<crafter::Packet>> {
+        let mut retransmits = 0;
+
+        loop {
+            if let Some(packet) = self.conversation.recv_matching(matcher, ctx, timeout)? {
+                return Ok(Some(packet));
+            }
+
+            if !self.retransmit_outstanding(current_state, retransmits)? {
+                return Ok(None);
+            }
+
+            retransmits += 1;
+        }
+    }
+
+    fn retransmit_outstanding(&mut self, current_state: &str, retransmits: u32) -> Result<bool> {
+        let Some(policy) = self.options.retransmit else {
+            return Ok(false);
+        };
+
+        if retransmits >= policy.count() {
+            return Ok(false);
+        }
+
+        let Some(outstanding) = self.outstanding_segment.as_ref() else {
+            return Ok(false);
+        };
+
+        if outstanding.awaiting_state != current_state {
+            return Ok(false);
+        }
+
+        let interval = policy.interval();
+        if !interval.is_zero() {
+            thread::sleep(interval);
+        }
+
+        let packet = outstanding.packet.clone();
+        self.send_packet(&packet)?;
+        Ok(true)
+    }
+
+    fn send_packet(&mut self, packet: &crafter::Packet) -> Result<()> {
+        let tcp_payload_bytes = tcp_payload_len(packet);
+        let report = self.conversation.send(packet)?;
+        self.tcp_payload_bytes_sent += tcp_payload_bytes;
+        self.send_reports.push(report);
+        Ok(())
     }
 
     fn build_report(
@@ -570,6 +651,25 @@ mod tests {
             .state(emit)
             .state(done)
             .initial("Emit")
+    }
+
+    fn waiting_reply_flow(name: &str, packet: crafter::Packet) -> Flow {
+        let transition = Transition::on(
+            PredicateMatcher::new("never matches", |_packet, _ctx| false),
+            |_packet, _ctx| Ok(Step::goto("Done")),
+        )
+        .targets(["Done"]);
+        let waiting = FlowState::new("Waiting")
+            .on_entry(move |_ctx| Ok(Step::send(packet.clone())))
+            .on(transition);
+        let done = FlowState::new("Done")
+            .on_entry(|_ctx| Ok(Step::done()))
+            .entry_terminal();
+
+        Flow::new(name)
+            .state(waiting)
+            .state(done)
+            .initial("Waiting")
     }
 
     struct RecordingTimeoutSource {
@@ -1346,6 +1446,44 @@ mod tests {
         assert_eq!(report.outcome(), &FlowOutcome::TimedOut);
         assert_eq!(report.visited_states(), &["Waiting".to_string()]);
         assert_eq!(report.iterations(), 0);
+    }
+
+    #[test]
+    fn runner_without_retransmit_sends_outstanding_segment_once_before_timeout() {
+        let mut flow = waiting_reply_flow("runner-no-retransmit", request_packet());
+        let options = RunOptions::default().step_timeout(Duration::from_millis(1));
+        let mut runner = Runner::with_source(options, MemoryCaptureSource::default())
+            .expect("runner opens with empty source");
+
+        let report = runner
+            .run(&mut flow)
+            .expect("runner returns timeout report");
+
+        assert_eq!(report.outcome(), &FlowOutcome::TimedOut);
+        assert_eq!(report.sent_count(), 1);
+        assert_eq!(runner.send_reports().len(), 1);
+    }
+
+    #[test]
+    fn runner_retransmit_policy_reemits_outstanding_segment_before_timeout() {
+        let mut flow = waiting_reply_flow("runner-retransmit", request_packet());
+        let options = RunOptions::default()
+            .step_timeout(Duration::from_millis(1))
+            .retransmit(2, Duration::ZERO);
+        let mut runner = Runner::with_source(options, MemoryCaptureSource::default())
+            .expect("runner opens with empty source");
+
+        let report = runner
+            .run(&mut flow)
+            .expect("runner returns timeout report");
+
+        assert_eq!(report.outcome(), &FlowOutcome::TimedOut);
+        assert_eq!(report.sent_count(), 3);
+        assert_eq!(runner.send_reports().len(), 3);
+        assert!(runner
+            .send_reports()
+            .iter()
+            .all(crafter::net::SendReport::is_dry_run));
     }
 
     #[test]

--- a/tools/flow/src/runner.rs
+++ b/tools/flow/src/runner.rs
@@ -71,6 +71,7 @@ pub struct Runner {
     conversation: Conversation,
     mutator: Box<dyn Mutator>,
     send_reports: Vec<SendReport>,
+    tcp_payload_bytes_sent: usize,
 }
 
 impl Runner {
@@ -138,6 +139,7 @@ impl Runner {
             conversation,
             mutator: Box::new(Identity),
             send_reports: Vec::new(),
+            tcp_payload_bytes_sent: 0,
         })
     }
 
@@ -383,7 +385,9 @@ impl Runner {
                     }
 
                     let packet = self.mutator.mutate(packet.clone(), iteration, ctx)?;
+                    let tcp_payload_bytes = tcp_payload_len(&packet);
                     let report = self.conversation.send(&packet)?;
+                    self.tcp_payload_bytes_sent += tcp_payload_bytes;
                     self.send_reports.push(report);
                 }
             }
@@ -435,6 +439,10 @@ impl Runner {
             outcome,
             ctx.summary(),
         )
+        .with_tcp_payload(
+            self.tcp_payload_bytes_sent,
+            ctx.tcp_received_payload().to_vec(),
+        )
     }
 
     fn run_timeout_elapsed(&self, elapsed: Duration) -> bool {
@@ -478,6 +486,18 @@ impl Runner {
             state
         )))
     }
+}
+
+fn tcp_payload_len(packet: &crafter::Packet) -> usize {
+    if packet.layer::<crafter::Tcp>().is_none() {
+        return 0;
+    }
+
+    packet
+        .layers::<crafter::Raw>()
+        .map(crafter::Raw::as_bytes)
+        .map(<[u8]>::len)
+        .sum()
 }
 
 #[cfg(test)]

--- a/tools/flow/tests/tcp_client_flow.rs
+++ b/tools/flow/tests/tcp_client_flow.rs
@@ -109,6 +109,22 @@ fn fin_ack_from_peer(local_port: u16, peer_seq: u32, ack: u32) -> crafter::Packe
     )
 }
 
+fn rst_ack_from_peer(local_port: u16, peer_seq: u32, ack: u32) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(remote_ipv4())
+            .dst(local_ipv4())
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(REMOTE_PORT)
+                .dport(local_port)
+                .seq(peer_seq)
+                .ack(ack)
+                .window(PEER_WINDOW)
+                .rst_ack_segment(),
+    )
+}
+
 fn sent_packet(report: &crafter::net::SendReport) -> crafter::Packet {
     assert!(report.is_dry_run());
     crafter::Packet::decode_from_l3(crafter::NetworkLayer::Ipv4, report.plan().bytes())
@@ -272,6 +288,150 @@ fn tcp_client_flow_completes_offline_with_peer_data_and_graceful_close() {
         peer_data_end.wrapping_add(1)
     );
     assert_eq!(final_ack.flags_value(), crafter::TCP_FLAG_ACK);
+}
+
+#[test]
+fn tcp_client_ignores_stray_segment_for_different_port() {
+    let client_payload = b"client payload".to_vec();
+    let peer_payload = b"server reply".to_vec();
+    let (local_port, _client_iss, client_snd_nxt) = client_syn_numbers(&client_payload);
+    let client_data_end = client_snd_nxt.wrapping_add(client_payload.len() as u32);
+    let peer_data_seq = PEER_ISS.wrapping_add(1);
+    let peer_data_end = peer_data_seq.wrapping_add(peer_payload.len() as u32);
+    let client_fin_end = client_data_end.wrapping_add(1);
+    let source = MemoryCaptureSource::new(vec![
+        data_from_peer(
+            local_port.wrapping_add(1),
+            peer_data_seq,
+            client_data_end,
+            b"stray data",
+        ),
+        syn_ack_from_peer(local_port, PEER_ISS, client_snd_nxt),
+        data_from_peer(local_port, peer_data_seq, client_data_end, &peer_payload),
+        ack_from_peer(local_port, peer_data_end, client_fin_end),
+        fin_ack_from_peer(local_port, peer_data_end, client_fin_end),
+    ]);
+    let mut flow = client_flow(
+        local_ipv4(),
+        remote_ipv4(),
+        REMOTE_PORT,
+        Some(client_payload),
+    );
+    let mut runner = Runner::with_source(RunOptions::default(), source)
+        .expect("offline runner opens with scripted TCP peer");
+
+    let report = runner.run(&mut flow).expect("TCP client flow runs");
+
+    assert_eq!(report.outcome(), &FlowOutcome::Completed);
+    assert_eq!(report.final_state(), Some(CLOSED));
+    assert_eq!(report.received_count(), 5);
+    assert_eq!(
+        report.visited_states(),
+        &[
+            SYN_SENT.to_string(),
+            ESTABLISHED.to_string(),
+            FIN_WAIT_1.to_string(),
+            FIN_WAIT_2.to_string(),
+            CLOSED.to_string(),
+        ]
+    );
+
+    let sent = runner
+        .send_reports()
+        .iter()
+        .map(sent_packet)
+        .collect::<Vec<_>>();
+    assert_eq!(sent.len(), 6);
+    assert_eq!(
+        tcp(&sent[1]).acknowledgment_number_value(),
+        PEER_ISS.wrapping_add(1)
+    );
+}
+
+#[test]
+fn tcp_client_rst_after_handshake_closes_cleanly() {
+    let client_payload = b"client payload before reset".to_vec();
+    let (local_port, _client_iss, client_snd_nxt) = client_syn_numbers(&client_payload);
+    let client_data_end = client_snd_nxt.wrapping_add(client_payload.len() as u32);
+    let source = MemoryCaptureSource::new(vec![
+        syn_ack_from_peer(local_port, PEER_ISS, client_snd_nxt),
+        rst_ack_from_peer(local_port, PEER_ISS.wrapping_add(1), client_data_end),
+    ]);
+    let mut flow = client_flow(
+        local_ipv4(),
+        remote_ipv4(),
+        REMOTE_PORT,
+        Some(client_payload),
+    );
+    let mut runner = Runner::with_source(RunOptions::default(), source)
+        .expect("offline runner opens with scripted TCP peer");
+
+    let report = runner.run(&mut flow).expect("TCP client flow runs");
+
+    assert_eq!(report.outcome(), &FlowOutcome::Completed);
+    assert_eq!(report.final_state(), Some(CLOSED));
+    assert_eq!(report.received_count(), 2);
+    assert_eq!(
+        report.visited_states(),
+        &[
+            SYN_SENT.to_string(),
+            ESTABLISHED.to_string(),
+            CLOSED.to_string(),
+        ]
+    );
+    assert_eq!(report.received_payload(), b"");
+    assert_eq!(runner.send_reports().len(), 3);
+}
+
+#[test]
+fn tcp_client_ignores_wrong_ack_syn_ack_until_correct_one_arrives() {
+    let client_payload = b"client payload".to_vec();
+    let peer_payload = b"server reply".to_vec();
+    let wrong_peer_iss = 0x1112_1314;
+    let (local_port, _client_iss, client_snd_nxt) = client_syn_numbers(&client_payload);
+    let client_data_end = client_snd_nxt.wrapping_add(client_payload.len() as u32);
+    let peer_data_seq = PEER_ISS.wrapping_add(1);
+    let peer_data_end = peer_data_seq.wrapping_add(peer_payload.len() as u32);
+    let client_fin_end = client_data_end.wrapping_add(1);
+    let source = MemoryCaptureSource::new(vec![
+        syn_ack_from_peer(
+            local_port,
+            wrong_peer_iss,
+            client_snd_nxt.wrapping_add(1),
+        ),
+        syn_ack_from_peer(local_port, PEER_ISS, client_snd_nxt),
+        data_from_peer(local_port, peer_data_seq, client_data_end, &peer_payload),
+        ack_from_peer(local_port, peer_data_end, client_fin_end),
+        fin_ack_from_peer(local_port, peer_data_end, client_fin_end),
+    ]);
+    let mut flow = client_flow(
+        local_ipv4(),
+        remote_ipv4(),
+        REMOTE_PORT,
+        Some(client_payload),
+    );
+    let mut runner = Runner::with_source(RunOptions::default(), source)
+        .expect("offline runner opens with scripted TCP peer");
+
+    let report = runner.run(&mut flow).expect("TCP client flow runs");
+
+    assert_eq!(report.outcome(), &FlowOutcome::Completed);
+    assert_eq!(report.final_state(), Some(CLOSED));
+    assert_eq!(report.received_count(), 5);
+
+    let sent = runner
+        .send_reports()
+        .iter()
+        .map(sent_packet)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        tcp(&sent[1]).acknowledgment_number_value(),
+        PEER_ISS.wrapping_add(1)
+    );
+    assert_ne!(
+        tcp(&sent[1]).acknowledgment_number_value(),
+        wrong_peer_iss.wrapping_add(1)
+    );
 }
 
 #[test]

--- a/tools/flow/tests/tcp_client_flow.rs
+++ b/tools/flow/tests/tcp_client_flow.rs
@@ -1,9 +1,9 @@
 use std::net::Ipv4Addr;
 
-use crafter_flow::flows::tcp::{client_flow, CLOSED, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, SYN_SENT};
-use crafter_flow::{
-    docaddr, FlowOutcome, MemoryCaptureSource, PacketContext, RunOptions, Runner,
+use crafter_flow::flows::tcp::{
+    client_flow, CLOSED, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, SYN_SENT,
 };
+use crafter_flow::{docaddr, FlowOutcome, MemoryCaptureSource, PacketContext, RunOptions, Runner};
 
 const REMOTE_PORT: u16 = 443;
 const PEER_ISS: u32 = 0x5152_5354;
@@ -126,6 +126,47 @@ fn tcp(packet: &crafter::Packet) -> &crafter::Tcp {
     packet.layer::<crafter::Tcp>().expect("packet has TCP")
 }
 
+fn run_client_exchange(
+    peer_iss: u32,
+    client_payload: &[u8],
+    peer_payload: &[u8],
+) -> (u32, u32, Vec<crafter::Packet>) {
+    let (local_port, client_iss, client_snd_nxt) = client_syn_numbers(client_payload);
+    let client_data_end = client_snd_nxt.wrapping_add(client_payload.len() as u32);
+    let peer_data_seq = peer_iss.wrapping_add(1);
+    let peer_data_end = peer_data_seq.wrapping_add(peer_payload.len() as u32);
+    let client_fin_end = client_data_end.wrapping_add(1);
+    let source = MemoryCaptureSource::new(vec![
+        syn_ack_from_peer(local_port, peer_iss, client_snd_nxt),
+        data_from_peer(local_port, peer_data_seq, client_data_end, peer_payload),
+        ack_from_peer(local_port, peer_data_end, client_fin_end),
+        fin_ack_from_peer(local_port, peer_data_end, client_fin_end),
+    ]);
+    let mut flow = client_flow(
+        local_ipv4(),
+        remote_ipv4(),
+        REMOTE_PORT,
+        Some(client_payload.to_vec()),
+    );
+    let mut runner = Runner::with_source(RunOptions::default(), source)
+        .expect("offline runner opens with scripted TCP peer");
+
+    let report = runner.run(&mut flow).expect("TCP client flow runs");
+
+    assert_eq!(report.outcome(), &FlowOutcome::Completed);
+    assert_eq!(report.final_state(), Some(CLOSED));
+    assert_eq!(report.received_payload(), peer_payload);
+
+    let sent = runner
+        .send_reports()
+        .iter()
+        .map(sent_packet)
+        .collect::<Vec<_>>();
+    assert_eq!(sent.len(), 6);
+
+    (client_iss, client_snd_nxt, sent)
+}
+
 fn local_ipv4() -> Ipv4Addr {
     docaddr::CLIENT_IPV4
 }
@@ -200,12 +241,11 @@ fn tcp_client_flow_completes_offline_with_peer_data_and_graceful_close() {
     assert_eq!(handshake_ack.flags_value(), crafter::TCP_FLAG_ACK);
 
     let data = tcp(&sent[2]);
-    let raw = sent[2].layer::<crafter::Raw>().expect("client data has Raw");
+    let raw = sent[2]
+        .layer::<crafter::Raw>()
+        .expect("client data has Raw");
     assert_eq!(data.sequence_number_value(), client_snd_nxt);
-    assert_eq!(
-        data.acknowledgment_number_value(),
-        PEER_ISS.wrapping_add(1)
-    );
+    assert_eq!(data.acknowledgment_number_value(), PEER_ISS.wrapping_add(1));
     assert_eq!(
         data.flags_value(),
         crafter::TCP_FLAG_PSH | crafter::TCP_FLAG_ACK
@@ -232,4 +272,62 @@ fn tcp_client_flow_completes_offline_with_peer_data_and_graceful_close() {
         peer_data_end.wrapping_add(1)
     );
     assert_eq!(final_ack.flags_value(), crafter::TCP_FLAG_ACK);
+}
+
+#[test]
+fn tcp_client_seq_ack_tracks_arbitrary_peer_iss() {
+    let client_payload = b"client bytes proving carry-forward";
+    let peer_payload = b"reply-from-large-peer-iss";
+    let peer_iss = 0x9F00_0000;
+    let alternate_peer_iss = 0xA500_1234;
+    let (client_iss, client_snd_nxt, sent) =
+        run_client_exchange(peer_iss, client_payload, peer_payload);
+    let (_, _, alternate_sent) =
+        run_client_exchange(alternate_peer_iss, client_payload, peer_payload);
+    let expected_peer_ack = peer_iss.wrapping_add(1);
+    let expected_peer_data_end = expected_peer_ack.wrapping_add(peer_payload.len() as u32);
+    let expected_client_data_end = client_iss
+        .wrapping_add(1)
+        .wrapping_add(client_payload.len() as u32);
+
+    let handshake_ack = tcp(&sent[1]);
+    assert_eq!(
+        handshake_ack.sequence_number_value(),
+        client_iss.wrapping_add(1)
+    );
+    assert_eq!(
+        handshake_ack.acknowledgment_number_value(),
+        expected_peer_ack
+    );
+
+    let data = tcp(&sent[2]);
+    assert_eq!(data.sequence_number_value(), client_iss.wrapping_add(1));
+    assert_eq!(data.sequence_number_value(), client_snd_nxt);
+    assert_eq!(data.acknowledgment_number_value(), expected_peer_ack);
+
+    let data_ack = tcp(&sent[3]);
+    assert_eq!(data_ack.sequence_number_value(), expected_client_data_end);
+    assert_eq!(
+        data_ack.acknowledgment_number_value(),
+        expected_peer_data_end
+    );
+
+    let fin = tcp(&sent[4]);
+    assert_eq!(fin.sequence_number_value(), expected_client_data_end);
+    assert_eq!(fin.acknowledgment_number_value(), expected_peer_data_end);
+
+    let alternate_handshake_ack = tcp(&alternate_sent[1]).acknowledgment_number_value();
+    let alternate_data_ack = tcp(&alternate_sent[3]).acknowledgment_number_value();
+    assert_ne!(
+        handshake_ack.acknowledgment_number_value(),
+        alternate_handshake_ack
+    );
+    assert_ne!(data_ack.acknowledgment_number_value(), alternate_data_ack);
+    assert_eq!(alternate_handshake_ack, alternate_peer_iss.wrapping_add(1));
+    assert_eq!(
+        alternate_data_ack,
+        alternate_peer_iss
+            .wrapping_add(1)
+            .wrapping_add(peer_payload.len() as u32)
+    );
 }

--- a/tools/flow/tests/tcp_client_flow.rs
+++ b/tools/flow/tests/tcp_client_flow.rs
@@ -1,4 +1,5 @@
 use std::net::Ipv4Addr;
+use std::time::Duration;
 
 use crafter_flow::flows::tcp::{
     client_flow, CLOSED, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, SYN_SENT,
@@ -486,4 +487,51 @@ fn tcp_client_seq_ack_tracks_arbitrary_peer_iss() {
             .wrapping_add(1)
             .wrapping_add(peer_payload.len() as u32)
     );
+}
+
+#[test]
+fn tcp_client_retransmits_syn_bounded_when_no_syn_ack_arrives() {
+    let mut flow = client_flow(
+        local_ipv4(),
+        remote_ipv4(),
+        REMOTE_PORT,
+        Some(b"client".to_vec()),
+    );
+    let options = RunOptions::default()
+        .step_timeout(Duration::from_millis(1))
+        .retransmit(2, Duration::ZERO);
+    let mut runner = Runner::with_source(options, MemoryCaptureSource::default())
+        .expect("offline runner opens with empty TCP peer");
+
+    let report = runner.run(&mut flow).expect("TCP client flow runs");
+
+    assert_eq!(report.outcome(), &FlowOutcome::TimedOut);
+    assert_eq!(report.final_state(), Some(SYN_SENT));
+    assert_eq!(report.received_count(), 0);
+    assert_eq!(report.sent_count(), 3);
+    assert_eq!(runner.send_reports().len(), 3);
+
+    let sent = runner
+        .send_reports()
+        .iter()
+        .map(sent_packet)
+        .collect::<Vec<_>>();
+    let first_syn = tcp(&sent[0]);
+    assert_eq!(first_syn.destination_port_value(), REMOTE_PORT);
+    assert_eq!(first_syn.acknowledgment_number_value(), 0);
+    assert_eq!(first_syn.flags_value(), crafter::TCP_FLAG_SYN);
+    let initial_syn = sent[0]
+        .compile()
+        .expect("initial SYN compiles")
+        .as_ref()
+        .to_vec();
+    for retransmitted in &sent[1..] {
+        assert_eq!(
+            retransmitted
+                .compile()
+                .expect("retransmitted SYN compiles")
+                .as_ref(),
+            initial_syn.as_slice()
+        );
+    }
 }

--- a/tools/flow/tests/tcp_client_flow.rs
+++ b/tools/flow/tests/tcp_client_flow.rs
@@ -394,11 +394,7 @@ fn tcp_client_ignores_wrong_ack_syn_ack_until_correct_one_arrives() {
     let peer_data_end = peer_data_seq.wrapping_add(peer_payload.len() as u32);
     let client_fin_end = client_data_end.wrapping_add(1);
     let source = MemoryCaptureSource::new(vec![
-        syn_ack_from_peer(
-            local_port,
-            wrong_peer_iss,
-            client_snd_nxt.wrapping_add(1),
-        ),
+        syn_ack_from_peer(local_port, wrong_peer_iss, client_snd_nxt.wrapping_add(1)),
         syn_ack_from_peer(local_port, PEER_ISS, client_snd_nxt),
         data_from_peer(local_port, peer_data_seq, client_data_end, &peer_payload),
         ack_from_peer(local_port, peer_data_end, client_fin_end),

--- a/tools/flow/tests/tcp_client_flow.rs
+++ b/tools/flow/tests/tcp_client_flow.rs
@@ -1,0 +1,235 @@
+use std::net::Ipv4Addr;
+
+use crafter_flow::flows::tcp::{client_flow, CLOSED, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, SYN_SENT};
+use crafter_flow::{
+    docaddr, FlowOutcome, MemoryCaptureSource, PacketContext, RunOptions, Runner,
+};
+
+const REMOTE_PORT: u16 = 443;
+const PEER_ISS: u32 = 0x5152_5354;
+const PEER_WINDOW: u16 = 32_768;
+const PEER_MSS: u16 = 1_200;
+
+fn client_syn_numbers(payload: &[u8]) -> (u16, u32, u32) {
+    let mut flow = client_flow(
+        local_ipv4(),
+        remote_ipv4(),
+        REMOTE_PORT,
+        Some(payload.to_vec()),
+    );
+    let mut context = PacketContext::new();
+    let step = flow
+        .state_mut(SYN_SENT)
+        .expect("SynSent state exists")
+        .run_entry(&mut context)
+        .expect("SynSent entry succeeds")
+        .expect("SynSent entry sends SYN");
+    let syn = step.outgoing().expect("SynSent entry has outgoing SYN");
+    let tcp = syn.layer::<crafter::Tcp>().expect("SYN has TCP layer");
+
+    (
+        tcp.source_port_value(),
+        tcp.sequence_number_value(),
+        context
+            .get_tcp_snd_nxt()
+            .expect("SynSent entry stores client snd_nxt"),
+    )
+}
+
+fn syn_ack_from_peer(local_port: u16, peer_seq: u32, ack: u32) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(remote_ipv4())
+            .dst(local_ipv4())
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(REMOTE_PORT)
+                .dport(local_port)
+                .seq(peer_seq)
+                .ack(ack)
+                .window(PEER_WINDOW)
+                .syn_ack_segment()
+                .tcp_option(crafter::TcpOption::maximum_segment_size(PEER_MSS))
+                .expect("fixed peer TCP MSS option encodes"),
+    )
+}
+
+fn ack_from_peer(local_port: u16, peer_seq: u32, ack: u32) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(remote_ipv4())
+            .dst(local_ipv4())
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(REMOTE_PORT)
+                .dport(local_port)
+                .seq(peer_seq)
+                .ack(ack)
+                .window(PEER_WINDOW)
+                .ack_segment(),
+    )
+}
+
+fn data_from_peer(
+    local_port: u16,
+    peer_seq: u32,
+    ack: u32,
+    payload: impl AsRef<[u8]>,
+) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(remote_ipv4())
+            .dst(local_ipv4())
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(REMOTE_PORT)
+                .dport(local_port)
+                .seq(peer_seq)
+                .ack(ack)
+                .window(PEER_WINDOW)
+                .ack_segment()
+                .psh()
+            / crafter::Raw::from_bytes(payload),
+    )
+}
+
+fn fin_ack_from_peer(local_port: u16, peer_seq: u32, ack: u32) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(remote_ipv4())
+            .dst(local_ipv4())
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(REMOTE_PORT)
+                .dport(local_port)
+                .seq(peer_seq)
+                .ack(ack)
+                .window(PEER_WINDOW)
+                .fin_ack_segment(),
+    )
+}
+
+fn sent_packet(report: &crafter::net::SendReport) -> crafter::Packet {
+    assert!(report.is_dry_run());
+    crafter::Packet::decode_from_l3(crafter::NetworkLayer::Ipv4, report.plan().bytes())
+        .expect("dry-run send plan decodes as IPv4")
+}
+
+fn decode_ipv4(packet: crafter::Packet) -> crafter::Packet {
+    let compiled = packet.compile().expect("TCP packet compiles");
+
+    crafter::Packet::decode_from_l3(crafter::NetworkLayer::Ipv4, compiled.as_bytes())
+        .expect("TCP packet decodes as IPv4")
+}
+
+fn tcp(packet: &crafter::Packet) -> &crafter::Tcp {
+    packet.layer::<crafter::Tcp>().expect("packet has TCP")
+}
+
+fn local_ipv4() -> Ipv4Addr {
+    docaddr::CLIENT_IPV4
+}
+
+fn remote_ipv4() -> Ipv4Addr {
+    docaddr::SERVER_IPV4
+}
+
+#[test]
+fn tcp_client_flow_completes_offline_with_peer_data_and_graceful_close() {
+    let client_payload = b"client payload".to_vec();
+    let peer_payload = b"server reply".to_vec();
+    let (local_port, client_iss, client_snd_nxt) = client_syn_numbers(&client_payload);
+    let client_data_end = client_snd_nxt.wrapping_add(client_payload.len() as u32);
+    let peer_data_seq = PEER_ISS.wrapping_add(1);
+    let peer_data_end = peer_data_seq.wrapping_add(peer_payload.len() as u32);
+    let client_fin_end = client_data_end.wrapping_add(1);
+    let source = MemoryCaptureSource::new(vec![
+        syn_ack_from_peer(local_port, PEER_ISS, client_snd_nxt),
+        ack_from_peer(local_port, peer_data_seq, client_data_end),
+        data_from_peer(local_port, peer_data_seq, client_data_end, &peer_payload),
+        ack_from_peer(local_port, peer_data_end, client_fin_end),
+        fin_ack_from_peer(local_port, peer_data_end, client_fin_end),
+    ]);
+    let mut flow = client_flow(
+        local_ipv4(),
+        remote_ipv4(),
+        REMOTE_PORT,
+        Some(client_payload.clone()),
+    );
+    let mut runner = Runner::with_source(RunOptions::default(), source)
+        .expect("offline runner opens with scripted TCP peer");
+
+    let report = runner.run(&mut flow).expect("TCP client flow runs");
+
+    assert_eq!(report.outcome(), &FlowOutcome::Completed);
+    assert_eq!(report.final_state(), Some(CLOSED));
+    assert_eq!(
+        report.visited_states(),
+        &[
+            SYN_SENT.to_string(),
+            ESTABLISHED.to_string(),
+            FIN_WAIT_1.to_string(),
+            FIN_WAIT_2.to_string(),
+            CLOSED.to_string(),
+        ]
+    );
+    assert_eq!(report.received_payload(), peer_payload.as_slice());
+    assert_eq!(report.bytes_received(), peer_payload.len());
+    assert_eq!(report.bytes_sent(), client_payload.len());
+
+    let sent = runner
+        .send_reports()
+        .iter()
+        .map(sent_packet)
+        .collect::<Vec<_>>();
+    assert_eq!(sent.len(), 6);
+
+    let syn = tcp(&sent[0]);
+    assert_eq!(syn.source_port_value(), local_port);
+    assert_eq!(syn.destination_port_value(), REMOTE_PORT);
+    assert_eq!(syn.sequence_number_value(), client_iss);
+    assert_eq!(syn.acknowledgment_number_value(), 0);
+    assert_eq!(syn.flags_value(), crafter::TCP_FLAG_SYN);
+
+    let handshake_ack = tcp(&sent[1]);
+    assert_eq!(handshake_ack.sequence_number_value(), client_snd_nxt);
+    assert_eq!(
+        handshake_ack.acknowledgment_number_value(),
+        PEER_ISS.wrapping_add(1)
+    );
+    assert_eq!(handshake_ack.flags_value(), crafter::TCP_FLAG_ACK);
+
+    let data = tcp(&sent[2]);
+    let raw = sent[2].layer::<crafter::Raw>().expect("client data has Raw");
+    assert_eq!(data.sequence_number_value(), client_snd_nxt);
+    assert_eq!(
+        data.acknowledgment_number_value(),
+        PEER_ISS.wrapping_add(1)
+    );
+    assert_eq!(
+        data.flags_value(),
+        crafter::TCP_FLAG_PSH | crafter::TCP_FLAG_ACK
+    );
+    assert_eq!(raw.as_bytes(), client_payload.as_slice());
+
+    let data_ack = tcp(&sent[3]);
+    assert_eq!(data_ack.sequence_number_value(), client_data_end);
+    assert_eq!(data_ack.acknowledgment_number_value(), peer_data_end);
+    assert_eq!(data_ack.flags_value(), crafter::TCP_FLAG_ACK);
+
+    let fin = tcp(&sent[4]);
+    assert_eq!(fin.sequence_number_value(), client_data_end);
+    assert_eq!(fin.acknowledgment_number_value(), peer_data_end);
+    assert_eq!(
+        fin.flags_value(),
+        crafter::TCP_FLAG_FIN | crafter::TCP_FLAG_ACK
+    );
+
+    let final_ack = tcp(&sent[5]);
+    assert_eq!(final_ack.sequence_number_value(), client_fin_end);
+    assert_eq!(
+        final_ack.acknowledgment_number_value(),
+        peer_data_end.wrapping_add(1)
+    );
+    assert_eq!(final_ack.flags_value(), crafter::TCP_FLAG_ACK);
+}

--- a/tools/flow/tests/tcp_server_flow.rs
+++ b/tools/flow/tests/tcp_server_flow.rs
@@ -153,11 +153,7 @@ fn tcp_server_flow_completes_offline_with_client_data_response_and_graceful_clos
         fin_ack_from_client(client_data_end, server_response_end),
         ack_from_client(client_fin_end, server_fin_end),
     ]);
-    let mut flow = server_flow(
-        server_ipv4(),
-        LISTEN_PORT,
-        Some(response_payload.clone()),
-    );
+    let mut flow = server_flow(server_ipv4(), LISTEN_PORT, Some(response_payload.clone()));
     let mut runner = Runner::with_source(RunOptions::default(), source)
         .expect("offline runner opens with scripted TCP client");
 

--- a/tools/flow/tests/tcp_server_flow.rs
+++ b/tools/flow/tests/tcp_server_flow.rs
@@ -12,13 +12,17 @@ const CLIENT_WINDOW: u16 = 32_768;
 const CLIENT_MSS: u16 = 1_200;
 
 fn syn_from_client(client_seq: u32) -> crafter::Packet {
+    syn_from_client_with_port(CLIENT_PORT, client_seq)
+}
+
+fn syn_from_client_with_port(client_port: u16, client_seq: u32) -> crafter::Packet {
     decode_ipv4(
         crafter::Ipv4::new()
             .src(client_ipv4())
             .dst(server_ipv4())
             .protocol(crafter::IPPROTO_TCP)
             / crafter::Tcp::new()
-                .sport(CLIENT_PORT)
+                .sport(client_port)
                 .dport(LISTEN_PORT)
                 .seq(client_seq)
                 .window(CLIENT_WINDOW)
@@ -29,13 +33,17 @@ fn syn_from_client(client_seq: u32) -> crafter::Packet {
 }
 
 fn ack_from_client(client_seq: u32, ack: u32) -> crafter::Packet {
+    ack_from_client_with_port(CLIENT_PORT, client_seq, ack)
+}
+
+fn ack_from_client_with_port(client_port: u16, client_seq: u32, ack: u32) -> crafter::Packet {
     decode_ipv4(
         crafter::Ipv4::new()
             .src(client_ipv4())
             .dst(server_ipv4())
             .protocol(crafter::IPPROTO_TCP)
             / crafter::Tcp::new()
-                .sport(CLIENT_PORT)
+                .sport(client_port)
                 .dport(LISTEN_PORT)
                 .seq(client_seq)
                 .ack(ack)
@@ -45,13 +53,22 @@ fn ack_from_client(client_seq: u32, ack: u32) -> crafter::Packet {
 }
 
 fn data_from_client(client_seq: u32, ack: u32, payload: impl AsRef<[u8]>) -> crafter::Packet {
+    data_from_client_with_port(CLIENT_PORT, client_seq, ack, payload)
+}
+
+fn data_from_client_with_port(
+    client_port: u16,
+    client_seq: u32,
+    ack: u32,
+    payload: impl AsRef<[u8]>,
+) -> crafter::Packet {
     decode_ipv4(
         crafter::Ipv4::new()
             .src(client_ipv4())
             .dst(server_ipv4())
             .protocol(crafter::IPPROTO_TCP)
             / crafter::Tcp::new()
-                .sport(CLIENT_PORT)
+                .sport(client_port)
                 .dport(LISTEN_PORT)
                 .seq(client_seq)
                 .ack(ack)
@@ -96,10 +113,14 @@ fn tcp(packet: &crafter::Packet) -> &crafter::Tcp {
 }
 
 fn discover_server_send_next() -> (u32, u32) {
+    discover_server_send_next_for(CLIENT_ISS)
+}
+
+fn discover_server_send_next_for(client_iss: u32) -> (u32, u32) {
     let mut flow = server_flow(server_ipv4(), LISTEN_PORT, None);
     let mut runner = Runner::with_source(
         RunOptions::default(),
-        MemoryCaptureSource::new(vec![syn_from_client(CLIENT_ISS)]),
+        MemoryCaptureSource::new(vec![syn_from_client(client_iss)]),
     )
     .expect("offline runner opens with scripted TCP SYN");
 
@@ -118,7 +139,7 @@ fn discover_server_send_next() -> (u32, u32) {
     assert_eq!(tcp.destination_port_value(), CLIENT_PORT);
     assert_eq!(
         tcp.acknowledgment_number_value(),
-        CLIENT_ISS.wrapping_add(1)
+        client_iss.wrapping_add(1)
     );
     assert_eq!(
         tcp.flags_value(),
@@ -126,6 +147,44 @@ fn discover_server_send_next() -> (u32, u32) {
     );
 
     (server_iss, server_iss.wrapping_add(1))
+}
+
+fn run_server_exchange(
+    client_iss: u32,
+    client_payload: &[u8],
+    response_payload: &[u8],
+) -> (u32, u32, Vec<crafter::Packet>) {
+    let (server_iss, server_snd_nxt) = discover_server_send_next_for(client_iss);
+    let client_snd_nxt = client_iss.wrapping_add(1);
+    let client_data_end = client_snd_nxt.wrapping_add(client_payload.len() as u32);
+    let server_response_end = server_snd_nxt.wrapping_add(response_payload.len() as u32);
+    let client_fin_end = client_data_end.wrapping_add(1);
+    let server_fin_end = server_response_end.wrapping_add(1);
+    let source = MemoryCaptureSource::new(vec![
+        syn_from_client(client_iss),
+        ack_from_client(client_snd_nxt, server_snd_nxt),
+        data_from_client(client_snd_nxt, server_snd_nxt, client_payload),
+        fin_ack_from_client(client_data_end, server_response_end),
+        ack_from_client(client_fin_end, server_fin_end),
+    ]);
+    let mut flow = server_flow(server_ipv4(), LISTEN_PORT, Some(response_payload.to_vec()));
+    let mut runner = Runner::with_source(RunOptions::default(), source)
+        .expect("offline runner opens with scripted TCP client");
+
+    let report = runner.run(&mut flow).expect("TCP server flow runs");
+
+    assert_eq!(report.outcome(), &FlowOutcome::Completed);
+    assert_eq!(report.final_state(), Some(CLOSED));
+    assert_eq!(report.received_payload(), client_payload);
+
+    let sent = runner
+        .send_reports()
+        .iter()
+        .map(sent_packet)
+        .collect::<Vec<_>>();
+    assert_eq!(sent.len(), 4);
+
+    (server_iss, server_snd_nxt, sent)
 }
 
 fn client_ipv4() -> Ipv4Addr {
@@ -221,4 +280,105 @@ fn tcp_server_flow_completes_offline_with_client_data_response_and_graceful_clos
         fin.flags_value(),
         crafter::TCP_FLAG_FIN | crafter::TCP_FLAG_ACK
     );
+}
+
+#[test]
+fn tcp_server_seq_ack_tracks_arbitrary_client_iss() {
+    let client_payload = b"client bytes proving server carry-forward";
+    let response_payload = b"server reply for arbitrary client iss";
+    let client_iss = 0x8F00_0010;
+    let alternate_client_iss = 0xA700_1234;
+    let (server_iss, server_snd_nxt, sent) =
+        run_server_exchange(client_iss, client_payload, response_payload);
+    let (_, _, alternate_sent) =
+        run_server_exchange(alternate_client_iss, client_payload, response_payload);
+    let client_snd_nxt = client_iss.wrapping_add(1);
+    let client_data_end = client_snd_nxt.wrapping_add(client_payload.len() as u32);
+    let client_fin_end = client_data_end.wrapping_add(1);
+
+    let syn_ack = tcp(&sent[0]);
+    assert_eq!(syn_ack.sequence_number_value(), server_iss);
+    assert_eq!(syn_ack.acknowledgment_number_value(), client_snd_nxt);
+
+    let response = tcp(&sent[1]);
+    assert_eq!(response.sequence_number_value(), server_snd_nxt);
+    assert_eq!(response.acknowledgment_number_value(), client_data_end);
+
+    let fin_ack = tcp(&sent[2]);
+    assert_eq!(
+        fin_ack.sequence_number_value(),
+        server_snd_nxt.wrapping_add(response_payload.len() as u32)
+    );
+    assert_eq!(fin_ack.acknowledgment_number_value(), client_fin_end);
+
+    let alternate_syn_ack = tcp(&alternate_sent[0]).acknowledgment_number_value();
+    let alternate_response_ack = tcp(&alternate_sent[1]).acknowledgment_number_value();
+    assert_ne!(syn_ack.acknowledgment_number_value(), alternate_syn_ack);
+    assert_ne!(
+        response.acknowledgment_number_value(),
+        alternate_response_ack
+    );
+    assert_eq!(alternate_syn_ack, alternate_client_iss.wrapping_add(1));
+    assert_eq!(
+        alternate_response_ack,
+        alternate_client_iss
+            .wrapping_add(1)
+            .wrapping_add(client_payload.len() as u32)
+    );
+}
+
+#[test]
+fn tcp_server_rejects_wrong_four_tuple_and_wrong_ack_segments() {
+    let client_payload = b"accepted client request".to_vec();
+    let response_payload = b"accepted server response".to_vec();
+    let (_server_iss, server_snd_nxt) = discover_server_send_next();
+    let client_snd_nxt = CLIENT_ISS.wrapping_add(1);
+    let client_data_end = client_snd_nxt.wrapping_add(client_payload.len() as u32);
+    let server_response_end = server_snd_nxt.wrapping_add(response_payload.len() as u32);
+    let client_fin_end = client_data_end.wrapping_add(1);
+    let server_fin_end = server_response_end.wrapping_add(1);
+    let wrong_ack = server_snd_nxt.wrapping_add(7);
+    let wrong_client_port = CLIENT_PORT.wrapping_add(1);
+    let source = MemoryCaptureSource::new(vec![
+        syn_from_client(CLIENT_ISS),
+        ack_from_client_with_port(wrong_client_port, client_snd_nxt, server_snd_nxt),
+        ack_from_client(client_snd_nxt, wrong_ack),
+        ack_from_client(client_snd_nxt, server_snd_nxt),
+        data_from_client_with_port(wrong_client_port, client_snd_nxt, server_snd_nxt, b"stray"),
+        data_from_client(client_snd_nxt, wrong_ack, b"wrong ack payload"),
+        data_from_client(client_snd_nxt, server_snd_nxt, &client_payload),
+        fin_ack_from_client(client_data_end, server_response_end),
+        ack_from_client(client_fin_end, server_fin_end),
+    ]);
+    let mut flow = server_flow(server_ipv4(), LISTEN_PORT, Some(response_payload.clone()));
+    let mut runner = Runner::with_source(RunOptions::default(), source)
+        .expect("offline runner opens with scripted TCP client");
+
+    let report = runner.run(&mut flow).expect("TCP server flow runs");
+
+    assert_eq!(report.outcome(), &FlowOutcome::Completed);
+    assert_eq!(report.final_state(), Some(CLOSED));
+    assert_eq!(report.received_count(), 9);
+    assert_eq!(report.received_payload(), client_payload.as_slice());
+    assert_eq!(
+        report.transitions_taken().len(),
+        5,
+        "only the valid SYN, ACK, data, FIN, and final ACK should transition"
+    );
+
+    let sent = runner
+        .send_reports()
+        .iter()
+        .map(sent_packet)
+        .collect::<Vec<_>>();
+    assert_eq!(sent.len(), 4);
+    let syn_ack = tcp(&sent[0]);
+    assert_eq!(syn_ack.acknowledgment_number_value(), client_snd_nxt);
+
+    let response = tcp(&sent[1]);
+    let response_raw = sent[1]
+        .layer::<crafter::Raw>()
+        .expect("server response has Raw payload");
+    assert_eq!(response.acknowledgment_number_value(), client_data_end);
+    assert_eq!(response_raw.as_bytes(), response_payload.as_slice());
 }

--- a/tools/flow/tests/tcp_server_flow.rs
+++ b/tools/flow/tests/tcp_server_flow.rs
@@ -1,0 +1,228 @@
+use std::net::Ipv4Addr;
+
+use crafter_flow::flows::tcp::{
+    server_flow, CLOSED, CLOSE_WAIT, ESTABLISHED, LAST_ACK, LISTEN, SYN_RECEIVED,
+};
+use crafter_flow::{docaddr, FlowOutcome, MemoryCaptureSource, RunOptions, Runner};
+
+const LISTEN_PORT: u16 = 8080;
+const CLIENT_PORT: u16 = 49_153;
+const CLIENT_ISS: u32 = 0x3132_3334;
+const CLIENT_WINDOW: u16 = 32_768;
+const CLIENT_MSS: u16 = 1_200;
+
+fn syn_from_client(client_seq: u32) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(client_ipv4())
+            .dst(server_ipv4())
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(CLIENT_PORT)
+                .dport(LISTEN_PORT)
+                .seq(client_seq)
+                .window(CLIENT_WINDOW)
+                .syn_segment()
+                .tcp_option(crafter::TcpOption::maximum_segment_size(CLIENT_MSS))
+                .expect("fixed client TCP MSS option encodes"),
+    )
+}
+
+fn ack_from_client(client_seq: u32, ack: u32) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(client_ipv4())
+            .dst(server_ipv4())
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(CLIENT_PORT)
+                .dport(LISTEN_PORT)
+                .seq(client_seq)
+                .ack(ack)
+                .window(CLIENT_WINDOW)
+                .ack_segment(),
+    )
+}
+
+fn data_from_client(client_seq: u32, ack: u32, payload: impl AsRef<[u8]>) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(client_ipv4())
+            .dst(server_ipv4())
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(CLIENT_PORT)
+                .dport(LISTEN_PORT)
+                .seq(client_seq)
+                .ack(ack)
+                .window(CLIENT_WINDOW)
+                .ack_segment()
+                .psh()
+            / crafter::Raw::from_bytes(payload),
+    )
+}
+
+fn fin_ack_from_client(client_seq: u32, ack: u32) -> crafter::Packet {
+    decode_ipv4(
+        crafter::Ipv4::new()
+            .src(client_ipv4())
+            .dst(server_ipv4())
+            .protocol(crafter::IPPROTO_TCP)
+            / crafter::Tcp::new()
+                .sport(CLIENT_PORT)
+                .dport(LISTEN_PORT)
+                .seq(client_seq)
+                .ack(ack)
+                .window(CLIENT_WINDOW)
+                .fin_ack_segment(),
+    )
+}
+
+fn decode_ipv4(packet: crafter::Packet) -> crafter::Packet {
+    let compiled = packet.compile().expect("TCP packet compiles");
+
+    crafter::Packet::decode_from_l3(crafter::NetworkLayer::Ipv4, compiled.as_bytes())
+        .expect("TCP packet decodes as IPv4")
+}
+
+fn sent_packet(report: &crafter::net::SendReport) -> crafter::Packet {
+    assert!(report.is_dry_run());
+    crafter::Packet::decode_from_l3(crafter::NetworkLayer::Ipv4, report.plan().bytes())
+        .expect("dry-run send plan decodes as IPv4")
+}
+
+fn tcp(packet: &crafter::Packet) -> &crafter::Tcp {
+    packet.layer::<crafter::Tcp>().expect("packet has TCP")
+}
+
+fn discover_server_send_next() -> (u32, u32) {
+    let mut flow = server_flow(server_ipv4(), LISTEN_PORT, None);
+    let mut runner = Runner::with_source(
+        RunOptions::default(),
+        MemoryCaptureSource::new(vec![syn_from_client(CLIENT_ISS)]),
+    )
+    .expect("offline runner opens with scripted TCP SYN");
+
+    let report = runner
+        .run(&mut flow)
+        .expect("TCP server SYN discovery run succeeds");
+
+    assert_eq!(report.outcome(), &FlowOutcome::TimedOut);
+    assert_eq!(runner.send_reports().len(), 1);
+
+    let syn_ack = sent_packet(&runner.send_reports()[0]);
+    let tcp = tcp(&syn_ack);
+    let server_iss = tcp.sequence_number_value();
+
+    assert_eq!(tcp.source_port_value(), LISTEN_PORT);
+    assert_eq!(tcp.destination_port_value(), CLIENT_PORT);
+    assert_eq!(
+        tcp.acknowledgment_number_value(),
+        CLIENT_ISS.wrapping_add(1)
+    );
+    assert_eq!(
+        tcp.flags_value(),
+        crafter::TCP_FLAG_SYN | crafter::TCP_FLAG_ACK
+    );
+
+    (server_iss, server_iss.wrapping_add(1))
+}
+
+fn client_ipv4() -> Ipv4Addr {
+    docaddr::CLIENT_IPV4
+}
+
+fn server_ipv4() -> Ipv4Addr {
+    docaddr::SERVER_IPV4
+}
+
+#[test]
+fn tcp_server_flow_completes_offline_with_client_data_response_and_graceful_close() {
+    let client_payload = b"client request bytes".to_vec();
+    let response_payload = b"server response bytes".to_vec();
+    let (server_iss, server_snd_nxt) = discover_server_send_next();
+    let client_snd_nxt = CLIENT_ISS.wrapping_add(1);
+    let client_data_end = client_snd_nxt.wrapping_add(client_payload.len() as u32);
+    let server_response_end = server_snd_nxt.wrapping_add(response_payload.len() as u32);
+    let client_fin_end = client_data_end.wrapping_add(1);
+    let server_fin_end = server_response_end.wrapping_add(1);
+    let source = MemoryCaptureSource::new(vec![
+        syn_from_client(CLIENT_ISS),
+        ack_from_client(client_snd_nxt, server_snd_nxt),
+        data_from_client(client_snd_nxt, server_snd_nxt, &client_payload),
+        fin_ack_from_client(client_data_end, server_response_end),
+        ack_from_client(client_fin_end, server_fin_end),
+    ]);
+    let mut flow = server_flow(
+        server_ipv4(),
+        LISTEN_PORT,
+        Some(response_payload.clone()),
+    );
+    let mut runner = Runner::with_source(RunOptions::default(), source)
+        .expect("offline runner opens with scripted TCP client");
+
+    let report = runner.run(&mut flow).expect("TCP server flow runs");
+
+    assert_eq!(report.outcome(), &FlowOutcome::Completed);
+    assert_eq!(report.final_state(), Some(CLOSED));
+    assert_eq!(
+        report.visited_states(),
+        &[
+            LISTEN.to_string(),
+            SYN_RECEIVED.to_string(),
+            ESTABLISHED.to_string(),
+            CLOSE_WAIT.to_string(),
+            LAST_ACK.to_string(),
+            CLOSED.to_string(),
+        ]
+    );
+    assert_eq!(report.received_payload(), client_payload.as_slice());
+    assert_eq!(report.bytes_received(), client_payload.len());
+    assert_eq!(report.bytes_sent(), response_payload.len());
+    assert_eq!(report.sent_count(), 4);
+    assert_eq!(runner.send_reports().len(), 4);
+
+    let sent = runner
+        .send_reports()
+        .iter()
+        .map(sent_packet)
+        .collect::<Vec<_>>();
+
+    let syn_ack = tcp(&sent[0]);
+    assert_eq!(syn_ack.source_port_value(), LISTEN_PORT);
+    assert_eq!(syn_ack.destination_port_value(), CLIENT_PORT);
+    assert_eq!(syn_ack.sequence_number_value(), server_iss);
+    assert_eq!(
+        syn_ack.acknowledgment_number_value(),
+        CLIENT_ISS.wrapping_add(1)
+    );
+    assert_eq!(
+        syn_ack.flags_value(),
+        crafter::TCP_FLAG_SYN | crafter::TCP_FLAG_ACK
+    );
+
+    let response = tcp(&sent[1]);
+    let response_raw = sent[1]
+        .layer::<crafter::Raw>()
+        .expect("server response has Raw payload");
+    assert_eq!(response.sequence_number_value(), server_snd_nxt);
+    assert_eq!(response.acknowledgment_number_value(), client_data_end);
+    assert_eq!(
+        response.flags_value(),
+        crafter::TCP_FLAG_PSH | crafter::TCP_FLAG_ACK
+    );
+    assert_eq!(response_raw.as_bytes(), response_payload.as_slice());
+
+    let fin_ack = tcp(&sent[2]);
+    assert_eq!(fin_ack.sequence_number_value(), server_response_end);
+    assert_eq!(fin_ack.acknowledgment_number_value(), client_fin_end);
+    assert_eq!(fin_ack.flags_value(), crafter::TCP_FLAG_ACK);
+
+    let fin = tcp(&sent[3]);
+    assert_eq!(fin.sequence_number_value(), server_response_end);
+    assert_eq!(fin.acknowledgment_number_value(), client_fin_end);
+    assert_eq!(
+        fin.flags_value(),
+        crafter::TCP_FLAG_FIN | crafter::TCP_FLAG_ACK
+    );
+}

--- a/tools/flow/tests/tcp_symmetry.rs
+++ b/tools/flow/tests/tcp_symmetry.rs
@@ -1,0 +1,285 @@
+use crafter_flow::flows::tcp::{
+    client_flow, server_flow, CLOSED, CLOSE_WAIT, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, LAST_ACK,
+    LISTEN, SYN_RECEIVED, SYN_SENT,
+};
+use crafter_flow::{docaddr, Flow, PacketContext, Role, Step};
+
+const LISTEN_PORT: u16 = 8080;
+
+struct StepDriver {
+    flow: Flow,
+    state: String,
+    context: PacketContext,
+    sent: Vec<crafter::Packet>,
+    visited: Vec<String>,
+    completed: bool,
+}
+
+impl StepDriver {
+    fn new(flow: Flow) -> Self {
+        let state = flow.initial().to_string();
+
+        Self {
+            flow,
+            state: state.clone(),
+            context: PacketContext::new(),
+            sent: Vec::new(),
+            visited: vec![state],
+            completed: false,
+        }
+    }
+
+    fn start(&mut self) {
+        self.settle_entry();
+    }
+
+    fn receive(&mut self, packet: &crafter::Packet) -> bool {
+        let step = {
+            let state = self
+                .flow
+                .state_mut(&self.state)
+                .expect("current state exists");
+            let Some(transition) = state.find_transition(packet, &self.context) else {
+                return false;
+            };
+
+            transition
+                .fire(packet, &mut self.context)
+                .expect("matched transition fires")
+        };
+
+        if self.apply_step(step) {
+            self.settle_entry();
+        }
+
+        true
+    }
+
+    fn settle_entry(&mut self) {
+        while !self.completed {
+            let step = self
+                .flow
+                .state_mut(&self.state)
+                .expect("current state exists")
+                .run_entry(&mut self.context)
+                .expect("state entry runs");
+            let Some(step) = step else {
+                return;
+            };
+
+            if !self.apply_step(step) {
+                return;
+            }
+        }
+    }
+
+    fn apply_step(&mut self, step: Step) -> bool {
+        let Step {
+            outgoing,
+            target,
+            terminal,
+            ..
+        } = step;
+
+        if let Some(packet) = outgoing {
+            self.sent.push(packet);
+        }
+
+        if let Some(target) = target {
+            self.state = target;
+            self.visited.push(self.state.clone());
+            if terminal {
+                self.completed = true;
+                return false;
+            }
+            return true;
+        }
+
+        if terminal {
+            self.completed = true;
+        }
+
+        false
+    }
+}
+
+fn tcp(packet: &crafter::Packet) -> &crafter::Tcp {
+    packet.layer::<crafter::Tcp>().expect("packet has TCP")
+}
+
+fn raw(packet: &crafter::Packet) -> &[u8] {
+    packet
+        .layer::<crafter::Raw>()
+        .expect("packet has Raw payload")
+        .as_bytes()
+}
+
+fn payload_bytes(packets: &[crafter::Packet]) -> Vec<u8> {
+    packets
+        .iter()
+        .filter_map(|packet| packet.layer::<crafter::Raw>())
+        .flat_map(|raw| raw.as_bytes().iter().copied())
+        .collect()
+}
+
+#[test]
+fn tcp_client_and_server_drive_each_other_offline() {
+    let client_payload = b"client bytes over offline TCP".to_vec();
+    let server_payload = b"server bytes over offline TCP".to_vec();
+
+    // Both halves use the same TCP segment grammar; only Role and open direction differ.
+    let client_flow = client_flow(
+        docaddr::CLIENT_IPV4,
+        docaddr::SERVER_IPV4,
+        LISTEN_PORT,
+        Some(client_payload.clone()),
+    );
+    let server_flow = server_flow(
+        docaddr::SERVER_IPV4,
+        LISTEN_PORT,
+        Some(server_payload.clone()),
+    );
+    assert_eq!(client_flow.role(), Role::Initiator);
+    assert_eq!(server_flow.role(), Role::Responder);
+
+    let mut client = StepDriver::new(client_flow);
+    let mut server = StepDriver::new(server_flow);
+
+    client.start();
+    assert_eq!(client.sent.len(), 1);
+    assert!(server.receive(&client.sent[0]));
+    assert!(client.receive(&server.sent[0]));
+    assert!(server.receive(&client.sent[1]));
+    assert!(server.receive(&client.sent[2]));
+    assert!(client.receive(&server.sent[1]));
+    assert!(!server.receive(&client.sent[3]));
+    assert!(server.receive(&client.sent[4]));
+    assert!(client.receive(&server.sent[2]));
+    assert!(client.receive(&server.sent[3]));
+    assert!(server.receive(&client.sent[5]));
+
+    assert!(client.completed);
+    assert!(server.completed);
+    assert_eq!(client.state, CLOSED);
+    assert_eq!(server.state, CLOSED);
+    assert_eq!(
+        client.visited,
+        [
+            SYN_SENT.to_string(),
+            ESTABLISHED.to_string(),
+            FIN_WAIT_1.to_string(),
+            FIN_WAIT_2.to_string(),
+            CLOSED.to_string(),
+        ]
+    );
+    assert_eq!(
+        server.visited,
+        [
+            LISTEN.to_string(),
+            SYN_RECEIVED.to_string(),
+            ESTABLISHED.to_string(),
+            CLOSE_WAIT.to_string(),
+            LAST_ACK.to_string(),
+            CLOSED.to_string(),
+        ]
+    );
+
+    assert_eq!(payload_bytes(&client.sent), client_payload);
+    assert_eq!(payload_bytes(&server.sent), server_payload);
+    assert_eq!(
+        client.context.tcp_received_payload(),
+        server_payload.as_slice()
+    );
+    assert_eq!(
+        server.context.tcp_received_payload(),
+        client_payload.as_slice()
+    );
+
+    let client_syn = tcp(&client.sent[0]);
+    let client_port = client_syn.source_port_value();
+    let client_iss = client_syn.sequence_number_value();
+    let client_snd_nxt = client_iss.wrapping_add(1);
+
+    assert_eq!(client_syn.destination_port_value(), LISTEN_PORT);
+    assert_eq!(client_syn.acknowledgment_number_value(), 0);
+    assert_eq!(client_syn.flags_value(), crafter::TCP_FLAG_SYN);
+
+    let server_syn_ack = tcp(&server.sent[0]);
+    let server_iss = server_syn_ack.sequence_number_value();
+    let server_snd_nxt = server_iss.wrapping_add(1);
+    let client_data_end = client_snd_nxt.wrapping_add(client_payload.len() as u32);
+    let server_data_end = server_snd_nxt.wrapping_add(server_payload.len() as u32);
+    let client_fin_end = client_data_end.wrapping_add(1);
+    let server_fin_end = server_data_end.wrapping_add(1);
+
+    assert_eq!(server_syn_ack.source_port_value(), LISTEN_PORT);
+    assert_eq!(server_syn_ack.destination_port_value(), client_port);
+    assert_eq!(server_syn_ack.acknowledgment_number_value(), client_snd_nxt);
+    assert_eq!(
+        server_syn_ack.flags_value(),
+        crafter::TCP_FLAG_SYN | crafter::TCP_FLAG_ACK
+    );
+
+    let client_handshake_ack = tcp(&client.sent[1]);
+    assert_eq!(client_handshake_ack.sequence_number_value(), client_snd_nxt);
+    assert_eq!(
+        client_handshake_ack.acknowledgment_number_value(),
+        server_snd_nxt
+    );
+    assert_eq!(client_handshake_ack.flags_value(), crafter::TCP_FLAG_ACK);
+
+    let client_data = tcp(&client.sent[2]);
+    assert_eq!(client_data.sequence_number_value(), client_snd_nxt);
+    assert_eq!(client_data.acknowledgment_number_value(), server_snd_nxt);
+    assert_eq!(
+        client_data.flags_value(),
+        crafter::TCP_FLAG_PSH | crafter::TCP_FLAG_ACK
+    );
+    assert_eq!(raw(&client.sent[2]), client_payload.as_slice());
+
+    let server_data = tcp(&server.sent[1]);
+    assert_eq!(server_data.sequence_number_value(), server_snd_nxt);
+    assert_eq!(server_data.acknowledgment_number_value(), client_data_end);
+    assert_eq!(
+        server_data.flags_value(),
+        crafter::TCP_FLAG_PSH | crafter::TCP_FLAG_ACK
+    );
+    assert_eq!(raw(&server.sent[1]), server_payload.as_slice());
+
+    let client_data_ack = tcp(&client.sent[3]);
+    assert_eq!(client_data_ack.sequence_number_value(), client_data_end);
+    assert_eq!(
+        client_data_ack.acknowledgment_number_value(),
+        server_data_end
+    );
+    assert_eq!(client_data_ack.flags_value(), crafter::TCP_FLAG_ACK);
+
+    let client_fin = tcp(&client.sent[4]);
+    assert_eq!(client_fin.sequence_number_value(), client_data_end);
+    assert_eq!(client_fin.acknowledgment_number_value(), server_data_end);
+    assert_eq!(
+        client_fin.flags_value(),
+        crafter::TCP_FLAG_FIN | crafter::TCP_FLAG_ACK
+    );
+
+    let server_fin_ack = tcp(&server.sent[2]);
+    assert_eq!(server_fin_ack.sequence_number_value(), server_data_end);
+    assert_eq!(server_fin_ack.acknowledgment_number_value(), client_fin_end);
+    assert_eq!(server_fin_ack.flags_value(), crafter::TCP_FLAG_ACK);
+
+    let server_fin = tcp(&server.sent[3]);
+    assert_eq!(server_fin.sequence_number_value(), server_data_end);
+    assert_eq!(server_fin.acknowledgment_number_value(), client_fin_end);
+    assert_eq!(
+        server_fin.flags_value(),
+        crafter::TCP_FLAG_FIN | crafter::TCP_FLAG_ACK
+    );
+
+    let client_final_ack = tcp(&client.sent[5]);
+    assert_eq!(client_final_ack.sequence_number_value(), client_fin_end);
+    assert_eq!(
+        client_final_ack.acknowledgment_number_value(),
+        server_fin_end
+    );
+    assert_eq!(client_final_ack.flags_value(), crafter::TCP_FLAG_ACK);
+}


### PR DESCRIPTION
## Summary

- add bounded IPv4 TCP client and server flow templates with handshake, payload, retransmit, reset, and graceful-close state
- carry sequence, acknowledgement, MSS, window, and received-payload state through inspectable flow reports
- export the templates through the flow prelude and add dry-run examples, offline conformance tests, symmetry coverage, and usage documentation

## Validation

- `.agents/scripts/check-conventional-commits --range origin/master..HEAD` - passed
- `.agents/scripts/check-crafter-release --static` - passed

## Notes

- Live provider validation was not repeated during landing; the tracked guide records the prior isolated-lab validation and the intentionally bounded first-cut TCP scope.