### PR TITLE
chore(crafter): prepare v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.4 - 2026-07-12
+
+### Changed
+
+- Add SCTP packet-layer coverage with typed chunks, parameters, causes, checksums, IPv4/IPv6 bindings, structured decode errors, fixtures, and oracle/probe validation.
+- Add a reusable stateful packet sender for raw-socket reuse across link, IPv4, batch, and send/receive workflows while retaining explicit live-mode safeguards.
+- Add the crafter-flow bounded conversation engine with dry-run-first ARP, DHCPv4, DNS, TCP, and QUIC flows, deterministic lifecycle handling, reporting, capture integration, and offline conformance coverage.
+
 ## 0.3.3 - 2026-07-03
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["target/package-self-test"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 rust-version = "1.78"
 description = "Packet-level network interaction for Rust tools and agents."


### PR DESCRIPTION
## Summary

- Prepare crafter v0.3.4 release metadata.
- Update the workspace version and changelog for SCTP, stateful packet sending, and bounded protocol flows.

## Validation

- `.agents/scripts/check-conventional-commits --range origin/master..HEAD`: passed
- `cargo generate-lockfile && cargo fetch --locked`: passed
- `.agents/scripts/check-crafter-release --static`: passed
- `cargo publish -p crafter --dry-run --locked`: passed

## Notes

- `Cargo.lock` was generated only as ignored ephemeral state.
- Package: 933 files, 12.6 MiB uncompressed, 2.2 MiB compressed.
- No validation was skipped.